### PR TITLE
[#55] Public API를 통해 호가정보, 체결 완료 정보를 호출하는 기능을 구현해요

### DIFF
--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -76,7 +76,7 @@
 		C329A8A227B14F8400193A4D /* OrderBookListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A8A127B14F8400193A4D /* OrderBookListView.swift */; };
 		C329A8A427B1502200193A4D /* OrderBookListViewCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A8A327B1502200193A4D /* OrderBookListViewCellData.swift */; };
 		C329A8AA27B15BE900193A4D /* CoinDetailSegmentedCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A8A927B15BE900193A4D /* CoinDetailSegmentedCategoryView.swift */; };
-		C333E9C727B19E17004F92CE /* OrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9C627B19E17004F92CE /* OrderBook.swift */; };
+		C333E9C727B19E17004F92CE /* OrderBookCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9C627B19E17004F92CE /* OrderBookCategory.swift */; };
 		C333E9CA27B259F1004F92CE /* CurrentPriceStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9C927B259F1004F92CE /* CurrentPriceStatusView.swift */; };
 		C333E9CC27B25D1A004F92CE /* CurrentPriceStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9CB27B25D1A004F92CE /* CurrentPriceStatusViewModel.swift */; };
 		C333E9D027B292B5004F92CE /* CoinDetailSegmentedCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9CF27B292B4004F92CE /* CoinDetailSegmentedCategoryViewModel.swift */; };
@@ -187,7 +187,7 @@
 		C329A8A127B14F8400193A4D /* OrderBookListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookListView.swift; sourceTree = "<group>"; };
 		C329A8A327B1502200193A4D /* OrderBookListViewCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookListViewCellData.swift; sourceTree = "<group>"; };
 		C329A8A927B15BE900193A4D /* CoinDetailSegmentedCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailSegmentedCategoryView.swift; sourceTree = "<group>"; };
-		C333E9C627B19E17004F92CE /* OrderBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBook.swift; sourceTree = "<group>"; };
+		C333E9C627B19E17004F92CE /* OrderBookCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookCategory.swift; sourceTree = "<group>"; };
 		C333E9C927B259F1004F92CE /* CurrentPriceStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPriceStatusView.swift; sourceTree = "<group>"; };
 		C333E9CB27B25D1A004F92CE /* CurrentPriceStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPriceStatusViewModel.swift; sourceTree = "<group>"; };
 		C333E9CF27B292B4004F92CE /* CoinDetailSegmentedCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailSegmentedCategoryViewModel.swift; sourceTree = "<group>"; };
@@ -615,7 +615,7 @@
 				C329A8A127B14F8400193A4D /* OrderBookListView.swift */,
 				C329A89B27B0C63600193A4D /* OrderBookListViewCell.swift */,
 				C329A8A327B1502200193A4D /* OrderBookListViewCellData.swift */,
-				C333E9C627B19E17004F92CE /* OrderBook.swift */,
+				C333E9C627B19E17004F92CE /* OrderBookCategory.swift */,
 			);
 			path = OrderBookListView;
 			sourceTree = "<group>";
@@ -919,7 +919,7 @@
 				B49FDAF827AA6C8D001A11E9 /* CharacterSet + Ext.swift in Sources */,
 				48256CDA27997246008F2AD1 /* ExchangeUseCase.swift in Sources */,
 				C329A87F27AECDA000193A4D /* CoinChartViewModel.swift in Sources */,
-				C333E9C727B19E17004F92CE /* OrderBook.swift in Sources */,
+				C333E9C727B19E17004F92CE /* OrderBookCategory.swift in Sources */,
 				4885375E27A3D91D00BE00FD /* TransactionCoordinator.swift in Sources */,
 				4885376027A3D92800BE00FD /* MoreOptionCoordinator.swift in Sources */,
 				C329A8AA27B15BE900193A4D /* CoinDetailSegmentedCategoryView.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		C333E9CC27B25D1A004F92CE /* CurrentPriceStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9CB27B25D1A004F92CE /* CurrentPriceStatusViewModel.swift */; };
 		C333E9D027B292B5004F92CE /* CoinDetailSegmentedCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9CF27B292B4004F92CE /* CoinDetailSegmentedCategoryViewModel.swift */; };
 		C333E9D227B294DD004F92CE /* CoinDetailCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9D127B294DD004F92CE /* CoinDetailCategory.swift */; };
+		C333E9DC27B2C3F2004F92CE /* TransactionHistoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */; };
+		C333E9DE27B2C40F004F92CE /* OrderBookResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */; };
 		C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF4127A1902000A5E4BE /* String + Ext.swift */; };
 		C3D0EF6B27A7682400A5E4BE /* ChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF6A27A7682400A5E4BE /* ChartData.swift */; };
 		C3D0EF6D27A7685100A5E4BE /* Array + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF6C27A7685100A5E4BE /* Array + Ext.swift */; };
@@ -192,6 +194,8 @@
 		C333E9CB27B25D1A004F92CE /* CurrentPriceStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPriceStatusViewModel.swift; sourceTree = "<group>"; };
 		C333E9CF27B292B4004F92CE /* CoinDetailSegmentedCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailSegmentedCategoryViewModel.swift; sourceTree = "<group>"; };
 		C333E9D127B294DD004F92CE /* CoinDetailCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailCategory.swift; sourceTree = "<group>"; };
+		C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryResponse.swift; sourceTree = "<group>"; };
+		C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookResponse.swift; sourceTree = "<group>"; };
 		C3D0EF4127A1902000A5E4BE /* String + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String + Ext.swift"; sourceTree = "<group>"; };
 		C3D0EF6A27A7682400A5E4BE /* ChartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartData.swift; sourceTree = "<group>"; };
 		C3D0EF6C27A7685100A5E4BE /* Array + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array + Ext.swift"; sourceTree = "<group>"; };
@@ -295,6 +299,8 @@
 				48B60E4B279FBF3B000534EC /* TickerResponse.swift */,
 				C329A80927AB8DA600193A4D /* CandleStickResponse.swift */,
 				48A49ECE27A9772000DF5124 /* SocketTickerResponse.swift */,
+				C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */,
+				C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -955,7 +961,9 @@
 				C329A88627AECEC100193A4D /* CoinDetailData.swift in Sources */,
 				C329A8A427B1502200193A4D /* OrderBookListViewCellData.swift in Sources */,
 				C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */,
+				C333E9DE27B2C40F004F92CE /* OrderBookResponse.swift in Sources */,
 				4881F42E2797A1C400472C90 /* ProductServiceViewController.swift in Sources */,
+				C333E9DC27B2C3F2004F92CE /* TransactionHistoryResponse.swift in Sources */,
 				4882FA6F279D288100A25880 /* Currency.swift in Sources */,
 				C329A88427AECEAF00193A4D /* Double + Ext.swift in Sources */,
 				48B60E4C279FBF3B000534EC /* TickerResponse.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookCategory.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookCategory.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum OrderBook {
+enum OrderBookCategory {
   case bid
   case ask
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCellData.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCellData.swift
@@ -10,7 +10,7 @@ import Foundation
 import Then
 
 struct OrderBookListViewCellData: Equatable {
-  let orderBook: OrderBook
+  let orderBook: OrderBookCategory
   let orderPrice: String
   let orderQuantity: String
   let priceChangedRatio: Double

--- a/Cryptocurrency/Cryptocurrency/Entity/OrderBookResponse.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/OrderBookResponse.swift
@@ -1,0 +1,63 @@
+//
+//  OrderBookResponse.swift
+//  Cryptocurrency
+//
+//  Created by 이영우 on 2022/02/09.
+//
+
+import Foundation
+
+/**
+ {
+   "status" : "0000",
+   "data" : {
+     "timestamp" : 1417142049868,
+     "order_currency" : "BTC",
+     "payment_currency" : "KRW",
+     "bids": [
+       {
+         "quantity" : "6.1189306",
+         "price" : "504000"
+       },
+       {
+         "quantity" : "10.35117828",
+         "price" : "503000"
+       }
+     ],
+     "asks": [
+       {
+         "quantity" : "2.67575",
+         "price" : "506000"
+       },
+       {
+         "quantity" : "3.54343",
+         "price" : "507000"
+       }
+     ]
+   }
+ }
+ */
+
+struct OrderBookResponse: Decodable {
+  let status: String
+  let data: OrderBookData
+}
+
+struct OrderBookData: Decodable {
+  let timestamp: Int
+  let orderCurrency: String
+  let paymentCurrency: String
+  let bids: [OrderBook]
+  let asks: [OrderBook]
+  
+  enum CodingKeys: String, CodingKey {
+    case timestamp, bids, asks
+    case orderCurrency = "order_currency"
+    case paymentCurrency = "payment_currency"
+  }
+}
+
+struct OrderBook: Decodable {
+  let quantity: String
+  let price: String
+}

--- a/Cryptocurrency/Cryptocurrency/Entity/TransactionHistoryResponse.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/TransactionHistoryResponse.swift
@@ -1,0 +1,49 @@
+//
+//  TransactionHistoryResponse.swift
+//  Cryptocurrency
+//
+//  Created by 이영우 on 2022/02/09.
+//
+
+import Foundation
+
+/**
+{
+   "status": "0000",
+   "data": [
+       {
+           "transaction_date": "2022-02-08 23:28:13",
+           "type": "bid",
+           "units_traded": "0.0034",
+           "price": "53221000",
+           "total": "180951"
+       },
+       {
+           "transaction_date": "2022-02-08 23:28:40",
+           "type": "bid",
+           "units_traded": "0.0312",
+           "price": "53219000",
+           "total": "1660432"
+       }
+   ]
+}
+*/
+
+struct TransactionHistoryResponse: Decodable {
+  let status: String
+  let data: [TransactionHistoryData]
+}
+
+struct TransactionHistoryData: Decodable {
+  let transactionDate: String
+  let type: String
+  let unitsTraded: String
+  let price: String
+  let total: String
+  
+  enum CodingKeys: String, CodingKey {
+    case transactionDate = "transaction_date"
+    case unitsTraded = "units_traded"
+    case type ,price, total
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/Network/NetworkRequestRouter.swift
+++ b/Cryptocurrency/Cryptocurrency/Network/NetworkRequestRouter.swift
@@ -13,6 +13,8 @@ enum NetworkRequestRouter: URLRequestConvertible {
   
   case fetchTickerData(OrderCurrency, PaymentCurrency)
   case fetchCandleStickData(OrderCurrency, PaymentCurrency, TimeUnit)
+  case fetchOrderBookData(OrderCurrency, PaymentCurrency)
+  case fetchTransactionHistoryData(OrderCurrency, PaymentCurrency)
 
   private var baseURLString: String {
     return "https://api.bithumb.com/public"
@@ -28,18 +30,27 @@ enum NetworkRequestRouter: URLRequestConvertible {
       return "/ticker" + "/\(orderCurrency.rawValue)_\(paymentCurrency.rawValue)"
     case .fetchCandleStickData(let orderCurrency, let paymentCurrency, let timeUnit):
       return "/candlestick/\(orderCurrency.rawValue)_\(paymentCurrency.rawValue)/\(timeUnit.rawValue)"
+    case .fetchOrderBookData(let orderCurrency, let paymentCurrency):
+      return "/orderbook/\(orderCurrency.rawValue)_\(paymentCurrency.rawValue)"
+    case .fetchTransactionHistoryData(let orderCurrency, let paymentCurrency):
+      return "/transaction_history/\(orderCurrency.rawValue)_\(paymentCurrency.rawValue)"
     }
   }
   
   func asURLRequest() throws -> URLRequest {
     let url = try (self.baseURLString + self.path).asURL()
-     var request = URLRequest(url: url)
-     request.httpMethod = self.HTTPMethod.rawValue
+    var request = URLRequest(url: url)
+    request.httpMethod = self.HTTPMethod.rawValue
+    request.cachePolicy = .reloadIgnoringCacheData
     
     switch self {
     case .fetchTickerData(_, _):
       return request
     case .fetchCandleStickData(_, _, _):
+      return request
+    case .fetchOrderBookData(_, _):
+      return request
+    case .fetchTransactionHistoryData(_, _):
       return request
     }
   }


### PR DESCRIPTION
## 배경
- #55 
- Public API를 통해 호가 정보, 체결 완료 정보를 호출하는 End Point를 추가합니다

## 수정 사항
- 이전 OrderBook의 종류를 나타내주는 타입인 `OrderBook` 을 `OrderBookCategory` 로 변경했어요
- 호가 정보, 체결 완료 정보를 통해서 받아와서 Decoding 해줄 Entity 타입을 생성했어요
- NetworkRequestRouter 타입에 호가 정보, 체결 완료 정보를 받아오는 EndPoint를 추가했어요
- NetworkManager에 호가정보, 체결완료 정보를 fetch하는 메서드를 추가하며, 중복 코드를 줄이기 위한 refactoring을 수행했어요

