### PR TITLE
[#59] REST API를 통해서 가상화폐 상세화면의 호가정보를 출력해요

### DIFF
--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		C333E9D227B294DD004F92CE /* CoinDetailCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9D127B294DD004F92CE /* CoinDetailCategory.swift */; };
 		C333E9DC27B2C3F2004F92CE /* TransactionHistoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */; };
 		C333E9DE27B2C40F004F92CE /* OrderBookResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */; };
+		C3D0B31527B50CBC005D4D61 /* OrderBookListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */; };
 		C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF4127A1902000A5E4BE /* String + Ext.swift */; };
 		C3D0EF6B27A7682400A5E4BE /* ChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF6A27A7682400A5E4BE /* ChartData.swift */; };
 		C3D0EF6D27A7685100A5E4BE /* Array + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF6C27A7685100A5E4BE /* Array + Ext.swift */; };
@@ -196,6 +197,7 @@
 		C333E9D127B294DD004F92CE /* CoinDetailCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailCategory.swift; sourceTree = "<group>"; };
 		C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryResponse.swift; sourceTree = "<group>"; };
 		C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookResponse.swift; sourceTree = "<group>"; };
+		C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookListViewModel.swift; sourceTree = "<group>"; };
 		C3D0EF4127A1902000A5E4BE /* String + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String + Ext.swift"; sourceTree = "<group>"; };
 		C3D0EF6A27A7682400A5E4BE /* ChartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartData.swift; sourceTree = "<group>"; };
 		C3D0EF6C27A7685100A5E4BE /* Array + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array + Ext.swift"; sourceTree = "<group>"; };
@@ -619,6 +621,7 @@
 			isa = PBXGroup;
 			children = (
 				C329A8A127B14F8400193A4D /* OrderBookListView.swift */,
+				C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */,
 				C329A89B27B0C63600193A4D /* OrderBookListViewCell.swift */,
 				C329A8A327B1502200193A4D /* OrderBookListViewCellData.swift */,
 				C333E9C627B19E17004F92CE /* OrderBookCategory.swift */,
@@ -932,6 +935,7 @@
 				C333E9D027B292B5004F92CE /* CoinDetailSegmentedCategoryViewModel.swift in Sources */,
 				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
 				489FB61E279BF10B0078AEE1 /* NetworkRequestRouter.swift in Sources */,
+				C3D0B31527B50CBC005D4D61 /* OrderBookListViewModel.swift in Sources */,
 				B4A8E115279AD60B00A2BFCD /* UIColor + Ext.swift in Sources */,
 				B49FDAFB27AAAFF5001A11E9 /* LetterSeparator.swift in Sources */,
 				C3D0EF9327A8A30500A5E4BE /* TimeUnitBottomSheetViewModel.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -65,7 +65,7 @@
 		C329A87D27AECD9900193A4D /* CoinChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A87C27AECD9900193A4D /* CoinChartView.swift */; };
 		C329A87F27AECDA000193A4D /* CoinChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A87E27AECDA000193A4D /* CoinChartViewModel.swift */; };
 		C329A88427AECEAF00193A4D /* Double + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A88327AECEAF00193A4D /* Double + Ext.swift */; };
-		C329A88627AECEC100193A4D /* CoinDetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A88527AECEC100193A4D /* CoinDetailData.swift */; };
+		C329A88627AECEC100193A4D /* CoinPriceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A88527AECEC100193A4D /* CoinPriceData.swift */; };
 		C329A88827AECFD600193A4D /* CryptoCurrencyDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A88727AECFD600193A4D /* CryptoCurrencyDataType.swift */; };
 		C329A88A27AED08400193A4D /* CoinDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A88927AED08400193A4D /* CoinDetailUseCase.swift */; };
 		C329A88D27AED1F700193A4D /* CoinDetailUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C329A88C27AED1F700193A4D /* CoinDetailUseCaseTests.swift */; };
@@ -179,7 +179,7 @@
 		C329A87C27AECD9900193A4D /* CoinChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinChartView.swift; sourceTree = "<group>"; };
 		C329A87E27AECDA000193A4D /* CoinChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinChartViewModel.swift; sourceTree = "<group>"; };
 		C329A88327AECEAF00193A4D /* Double + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double + Ext.swift"; sourceTree = "<group>"; };
-		C329A88527AECEC100193A4D /* CoinDetailData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailData.swift; sourceTree = "<group>"; };
+		C329A88527AECEC100193A4D /* CoinPriceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinPriceData.swift; sourceTree = "<group>"; };
 		C329A88727AECFD600193A4D /* CryptoCurrencyDataType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoCurrencyDataType.swift; sourceTree = "<group>"; };
 		C329A88927AED08400193A4D /* CoinDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailUseCase.swift; sourceTree = "<group>"; };
 		C329A88C27AED1F700193A4D /* CoinDetailUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailUseCaseTests.swift; sourceTree = "<group>"; };
@@ -423,7 +423,6 @@
 				4885376227A40E3600BE00FD /* CoinDetailViewController.swift */,
 				C3D0EF9B27A8AC1F00A5E4BE /* CoinDetailViewModel.swift */,
 				C329A88927AED08400193A4D /* CoinDetailUseCase.swift */,
-				C329A88527AECEC100193A4D /* CoinDetailData.swift */,
 				C333E9D127B294DD004F92CE /* CoinDetailCategory.swift */,
 				4885376427A40E4000BE00FD /* CoinDetailCoordinator.swift */,
 			);
@@ -643,6 +642,7 @@
 			children = (
 				C333E9C927B259F1004F92CE /* CurrentPriceStatusView.swift */,
 				C333E9CB27B25D1A004F92CE /* CurrentPriceStatusViewModel.swift */,
+				C329A88527AECEC100193A4D /* CoinPriceData.swift */,
 			);
 			path = CurrentPriceStatusView;
 			sourceTree = "<group>";
@@ -962,7 +962,7 @@
 				4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */,
 				48FDCFFC279541E2002F0050 /* AppDelegate.swift in Sources */,
 				4885375A27A3D88400BE00FD /* ProductServiceCoordinator.swift in Sources */,
-				C329A88627AECEC100193A4D /* CoinDetailData.swift in Sources */,
+				C329A88627AECEC100193A4D /* CoinPriceData.swift in Sources */,
 				C329A8A427B1502200193A4D /* OrderBookListViewCellData.swift in Sources */,
 				C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */,
 				C333E9DE27B2C40F004F92CE /* OrderBookResponse.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -15,9 +15,11 @@ protocol CoinDetailUseCaseLogic {
   func fetchCandleStick(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency, timeUnit: TimeUnit) -> Single<Result<CandleStickResponse, APINetworkError>>
   func fetchOrderBook(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency) -> Single<Result<OrderBookResponse, APINetworkError>>
   func response<T: Decodable>(result: Result<T, APINetworkError>) -> T?
-  func tickerData(response: AllTickerResponse?) -> (data: CoinDetailData, price: Double)?
+  func tickerData(response: AllTickerResponse?) -> CoinDetailData?
+  func openingPrice(for data: CoinDetailData) -> Double
   func chartData(response: CandleStickResponse?) -> [ChartData]
-  func orderBookListViewCellData(response: OrderBookResponse, openingPrice: Double) -> [OrderBookListViewCellData]
+  func bidsCellData(with response: OrderBookResponse, openingPrice: Double) -> [OrderBookListViewCellData]
+  func asksCellData(with response: OrderBookResponse, openingPrice: Double) -> [OrderBookListViewCellData]
 }
 
 final class CoinDetailUseCase: CoinDetailUseCaseLogic {
@@ -60,9 +62,8 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     return value
   }
 
-  func tickerData(response: AllTickerResponse?) -> (data: CoinDetailData, price: Double)? {
-    guard let data = response?.data.first,
-          let openingPrice = Double(data.value.openingPrice) else {
+  func tickerData(response: AllTickerResponse?) -> CoinDetailData? {
+    guard let data = response?.data.first else {
       return nil
     }
     return (
@@ -70,8 +71,16 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
         currentPrice: data.value.closingPrice,
         priceChangedRatio: data.value.fluctateRate24H,
         priceDifference: data.value.fluctate24H
-      ), openingPrice
+      )
     )
+  }
+
+  func openingPrice(for data: CoinDetailData) -> Double {
+    guard let currentPrice = Double(data.currentPrice),
+          let priceDifference = Double(data.priceDifference) else {
+            return 0
+          }
+    return currentPrice - priceDifference
   }
 
   func chartData(response: CandleStickResponse?) -> [ChartData] {
@@ -81,7 +90,60 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     return response.chartData
   }
 
-  func orderBookListViewCellData(response: OrderBookResponse, openingPrice: Double) -> [OrderBookListViewCellData] {
-    return response.orderBookListViewCellData(by: openingPrice)
+  func bidsCellData(with response: OrderBookResponse, openingPrice: Double) -> [OrderBookListViewCellData] {
+    let neededEmptyCellDataCount = 30 - response.data.bids.count
+    let emptyCellData = self.emptyCellData(orderBookCategory: .bid, count: neededEmptyCellDataCount)
+    let cellData = response.data.bids.sorted { lhs, rhs in
+      guard let lhsOrderPrice = Double(lhs.price),
+            let rhsOrderPrice = Double(rhs.price) else {
+              return true
+            }
+      return lhsOrderPrice > rhsOrderPrice
+    }.map { orderBook -> OrderBookListViewCellData? in
+      guard let orderPrice = Double(orderBook.price) else { return nil }
+      return OrderBookListViewCellData(
+        orderBookCategory: .bid,
+        orderPrice: orderBook.price,
+        orderQuantity: orderBook.quantity,
+        priceChangedRatio: (orderPrice - openingPrice) / orderPrice
+      )
+    }.compactMap { $0 }
+    
+    return cellData + emptyCellData
+  }
+
+  func asksCellData(with response: OrderBookResponse, openingPrice: Double) -> [OrderBookListViewCellData] {
+    let neededEmptyCellDataCount = 30 - response.data.asks.count
+    let emptyCellData = self.emptyCellData(orderBookCategory: .ask, count: neededEmptyCellDataCount)
+    let cellData = response.data.asks.sorted { lhs, rhs in
+      guard let lhsOrderPrice = Double(lhs.price),
+            let rhsOrderPrice = Double(rhs.price) else {
+              return true
+            }
+      return lhsOrderPrice > rhsOrderPrice
+    }.map { orderBook -> OrderBookListViewCellData? in
+      guard let orderPrice = Double(orderBook.price) else { return nil }
+      return OrderBookListViewCellData(
+        orderBookCategory: .ask,
+        orderPrice: orderBook.price,
+        orderQuantity: orderBook.quantity,
+        priceChangedRatio: (orderPrice - openingPrice) / orderPrice
+      )
+    }.compactMap { $0 }
+    
+    return emptyCellData + cellData
+  }
+
+  private func emptyCellData(orderBookCategory: OrderBookCategory, count: Int) -> [OrderBookListViewCellData] {
+    let emptyCellData = OrderBookListViewCellData(
+      orderBookCategory: orderBookCategory,
+      orderPrice: nil,
+      orderQuantity: nil,
+      priceChangedRatio: nil
+    )
+    return Array(
+      repeating: emptyCellData,
+      count: count
+    )
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -15,8 +15,8 @@ protocol CoinDetailUseCaseLogic {
   func fetchCandleStick(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency, timeUnit: TimeUnit) -> Single<Result<CandleStickResponse, APINetworkError>>
   func fetchOrderBook(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency) -> Single<Result<OrderBookResponse, APINetworkError>>
   func response<T: Decodable>(result: Result<T, APINetworkError>) -> T?
-  func tickerData(response: AllTickerResponse?) -> CoinDetailData?
-  func openingPrice(of data: CoinDetailData) -> Double
+  func tickerData(response: AllTickerResponse?) -> CoinPriceData?
+  func openingPrice(of data: CoinPriceData) -> Double
   func chartData(response: CandleStickResponse?) -> [ChartData]
   func orderBookListViewCellData(with response: OrderBookResponse, category: OrderBookCategory, openingPrice: Double) -> [OrderBookListViewCellData]
 }
@@ -61,12 +61,12 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     return value
   }
 
-  func tickerData(response: AllTickerResponse?) -> CoinDetailData? {
+  func tickerData(response: AllTickerResponse?) -> CoinPriceData? {
     guard let data = response?.data.first else {
       return nil
     }
     return (
-      CoinDetailData(
+      CoinPriceData(
         currentPrice: data.value.closingPrice,
         priceChangedRatio: data.value.fluctateRate24H,
         priceDifference: data.value.fluctate24H
@@ -74,7 +74,7 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     )
   }
 
-  func openingPrice(of data: CoinDetailData) -> Double {
+  func openingPrice(of data: CoinPriceData) -> Double {
     guard let currentPrice = Double(data.currentPrice),
           let priceDifference = Double(data.priceDifference) else {
             return 0

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -17,7 +17,7 @@ protocol CoinDetailUseCaseLogic {
   func response<T: Decodable>(result: Result<T, APINetworkError>) -> T?
   func tickerData(response: AllTickerResponse?) -> (data: CoinDetailData, price: Double)?
   func chartData(response: CandleStickResponse?) -> [ChartData]
-  func orderBookListViewCellData(response: OrderBookResponse?, openingPrice: Double?) -> [OrderBookListViewCellData]
+  func orderBookListViewCellData(response: OrderBookResponse, openingPrice: Double) -> [OrderBookListViewCellData]
 }
 
 final class CoinDetailUseCase: CoinDetailUseCaseLogic {
@@ -81,10 +81,7 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     return response.chartData
   }
 
-  func orderBookListViewCellData(response: OrderBookResponse?, openingPrice: Double?) -> [OrderBookListViewCellData] {
-    guard let response = response, let openingPrice = openingPrice else {
-      return []
-    }
+  func orderBookListViewCellData(response: OrderBookResponse, openingPrice: Double) -> [OrderBookListViewCellData] {
     return response.orderBookListViewCellData(by: openingPrice)
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
@@ -115,6 +115,7 @@ final class CoinDetailViewController: UIViewController {
     self.coinDetailSegmentedCategoryView.bind(viewModel: self.coinDetailViewModel.coinDetailSegmentedCategoryViewModel)
     self.coinChartView.bind(viewModel: self.coinDetailViewModel.coinChartViewModel)
     self.currentPriceStatusView.bind(viewModel: self.coinDetailViewModel.currentPriceStatusViewModel)
+    self.orderBookListView.bind(viewModel: self.coinDetailViewModel.orderBookListViewModel)
 
     self.timeUnitChangeButton.rx.tap
       .bind(to: self.coinDetailViewModel.tapSelectTimeUnitButton)

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
@@ -138,9 +138,9 @@ final class CoinDetailViewController: UIViewController {
       self.coinChartView.isHidden = true
       self.timeUnitChangeButton.isHidden = true
     case .chart:
+      self.orderBookListView.isHidden = true
       self.coinChartView.isHidden = false
       self.timeUnitChangeButton.isHidden = false
-      self.orderBookListView.isHidden = true
     case .transactionHistory:
       break
     }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
@@ -125,5 +125,24 @@ final class CoinDetailViewController: UIViewController {
       .bind {
         self.timeUnitChangeButton.setTitle($0.rawValue, for: .normal)
       }.disposed(by: self.disposeBag)
+    
+    self.coinDetailViewModel.coinDetailSegmentedCategoryViewModel.category
+      .bind(onNext: changeContentView)
+      .disposed(by: self.disposeBag)
+  }
+  
+  private func changeContentView(by category: CoinDetailCategory) {
+    switch category {
+    case .orderBook:
+      self.orderBookListView.isHidden = false
+      self.coinChartView.isHidden = true
+      self.timeUnitChangeButton.isHidden = true
+    case .chart:
+      self.coinChartView.isHidden = false
+      self.timeUnitChangeButton.isHidden = false
+      self.orderBookListView.isHidden = true
+    case .transactionHistory:
+      break
+    }
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -57,15 +57,16 @@ final class CoinDetailViewModel {
 
     let tickerData = tickerResponse
       .map(useCase.tickerData)
+      .filter { $0 != nil }
 
     tickerData
-      .map { $0?.data }
+      .map { $0!.data }
       .asObservable()
       .bind(to: self.currentPriceStatusViewModel.coinDetailData)
       .disposed(by: self.disposeBag)
 
     tickerData
-      .map { $0?.price }
+      .map { $0!.price }
       .asObservable()
       .bind(to: self.orderBookListViewModel.openingPrice)
       .disposed(by: self.disposeBag)
@@ -76,6 +77,7 @@ final class CoinDetailViewModel {
     let orderBookResponse = orderBookResult
       .map(useCase.response)
       .filter { $0 != nil }
+      .map { $0! }
       .asObservable()
 
     Observable.combineLatest(

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -17,6 +17,7 @@ final class CoinDetailViewModel {
   let coinChartViewModel = CoinChartViewModel()
   let currentPriceStatusViewModel = CurrentPriceStatusViewModel()
   let coinDetailSegmentedCategoryViewModel = CoinDetailSegmentedCategoryViewModel()
+  let orderBookListViewModel = OrderBookListViewModel()
   var coinDetailCoordinator: CoinDetailCoordinator?
 
   private let disposeBag = DisposeBag()

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -84,15 +84,19 @@ final class CoinDetailViewModel {
     Observable.combineLatest(
       orderBookResponse,
       self.openingPrice
-    ).map(useCase.asksCellData)
-      .bind(to: self.orderBookListViewModel.askCellData)
-      .disposed(by: self.disposeBag)
+    ).map { (response, openingPrice) in
+      useCase.orderBookListViewCellData(with: response, category: .ask, openingPrice: openingPrice)
+    }
+    .bind(to: self.orderBookListViewModel.askCellData)
+    .disposed(by: self.disposeBag)
 
     Observable.combineLatest(
       orderBookResponse,
       self.openingPrice
-    ).map(useCase.bidsCellData)
-      .bind(to: self.orderBookListViewModel.bidCellData)
-      .disposed(by: self.disposeBag)
+    ).map { (response, openingPrice) in
+      useCase.orderBookListViewCellData(with: response, category: .bid, openingPrice: openingPrice)
+    }
+    .bind(to: self.orderBookListViewModel.bidCellData)
+    .disposed(by: self.disposeBag)
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -63,7 +63,7 @@ final class CoinDetailViewModel {
 
     tickerData
       .asObservable()
-      .bind(to: self.currentPriceStatusViewModel.coinDetailData)
+      .bind(to: self.currentPriceStatusViewModel.coinPriceData)
       .disposed(by: self.disposeBag)
 
     tickerData

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -85,18 +85,11 @@ final class CoinDetailViewModel {
       orderBookResponse,
       self.openingPrice
     ).map { (response, openingPrice) in
-      useCase.orderBookListViewCellData(with: response, category: .ask, openingPrice: openingPrice)
+      let bids = useCase.orderBookListViewCellData(with: response, category: .bid, openingPrice: openingPrice)
+      let asks = useCase.orderBookListViewCellData(with: response, category: .ask, openingPrice: openingPrice)
+      return asks + bids
     }
-    .bind(to: self.orderBookListViewModel.askCellData)
-    .disposed(by: self.disposeBag)
-
-    Observable.combineLatest(
-      orderBookResponse,
-      self.openingPrice
-    ).map { (response, openingPrice) in
-      useCase.orderBookListViewCellData(with: response, category: .bid, openingPrice: openingPrice)
-    }
-    .bind(to: self.orderBookListViewModel.bidCellData)
+    .bind(to: self.orderBookListViewModel.orderBookListViewCellData)
     .disposed(by: self.disposeBag)
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CoinPriceData.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CoinPriceData.swift
@@ -1,5 +1,5 @@
 //
-//  CoinDetailData.swift
+//  CoinPriceData.swift
 //  Cryptocurrency
 //
 //  Created by 이영우 on 2022/02/05.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-struct CoinDetailData: Equatable, CryptoCurrencyDataType {
+struct CoinPriceData: Equatable, CryptoCurrencyDataType {
   let currentPrice: String
   let priceChangedRatio: String
   let priceDifference: String

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusView.swift
@@ -71,9 +71,9 @@ final class CurrentPriceStatusView: UIView {
       .disposed(by: self.disposeBag)
   }
   
-  private func setCoinDetailData(with coinDetailData: CoinDetailData?) {
-    self.currentPriceLabel.attributedText = coinDetailData?.currentPriceText()
-    self.priceDifferenceLabel.attributedText = coinDetailData?.priceDifferenceText()
-    self.priceChangedRatioLabel.attributedText = coinDetailData?.priceChangedRatioText()
+  private func setCoinDetailData(with coinDetailData: CoinDetailData) {
+    self.currentPriceLabel.attributedText = coinDetailData.currentPriceText()
+    self.priceDifferenceLabel.attributedText = coinDetailData.priceDifferenceText()
+    self.priceChangedRatioLabel.attributedText = coinDetailData.priceChangedRatioText()
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusView.swift
@@ -66,14 +66,14 @@ final class CurrentPriceStatusView: UIView {
   // MARK: Binding
   
   func bind(viewModel: CurrentPriceStatusViewModel) {
-    viewModel.coinDetailData
+    viewModel.coinPriceData
       .bind(onNext: self.setCoinDetailData)
       .disposed(by: self.disposeBag)
   }
   
-  private func setCoinDetailData(with coinDetailData: CoinDetailData) {
-    self.currentPriceLabel.attributedText = coinDetailData.currentPriceText()
-    self.priceDifferenceLabel.attributedText = coinDetailData.priceDifferenceText()
-    self.priceChangedRatioLabel.attributedText = coinDetailData.priceChangedRatioText()
+  private func setCoinDetailData(with coinPriceData: CoinPriceData) {
+    self.currentPriceLabel.attributedText = coinPriceData.currentPriceText()
+    self.priceDifferenceLabel.attributedText = coinPriceData.priceDifferenceText()
+    self.priceChangedRatioLabel.attributedText = coinPriceData.priceChangedRatioText()
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusViewModel.swift
@@ -8,9 +8,9 @@
 import RxRelay
 
 protocol CurrentPriceStatusViewModelLogic {
-  var coinDetailData: PublishRelay<CoinDetailData?> { get }
+  var coinDetailData: PublishRelay<CoinDetailData> { get }
 }
 
 final class CurrentPriceStatusViewModel: CurrentPriceStatusViewModelLogic {
-  let coinDetailData = PublishRelay<CoinDetailData?>()
+  let coinDetailData = PublishRelay<CoinDetailData>()
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusViewModel.swift
@@ -8,9 +8,9 @@
 import RxRelay
 
 protocol CurrentPriceStatusViewModelLogic {
-  var coinDetailData: PublishRelay<CoinDetailData> { get }
+  var coinPriceData: PublishRelay<CoinPriceData> { get }
 }
 
 final class CurrentPriceStatusViewModel: CurrentPriceStatusViewModelLogic {
-  let coinDetailData = PublishRelay<CoinDetailData>()
+  let coinPriceData = PublishRelay<CoinPriceData>()
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
@@ -12,6 +12,11 @@ import RxSwift
 
 final class OrderBookListView: UITableView {
 
+  // MARK: Properties
+  
+  private let disposeBag = DisposeBag()
+  
+  
   // MARK: Initializers
   
   override init(frame: CGRect, style: UITableView.Style) {
@@ -32,8 +37,20 @@ final class OrderBookListView: UITableView {
     self.rowHeight = 40
   }
   
-  func bind() {
-    // TODO: 매개변수로 ViewModel을 받아와 Binding을 진행
+  func bind(viewModel: OrderBookListViewModelLogic) {
+    viewModel.cellData
+      .bind(to: self.rx.items) { tableView, row, data in
+        let index = IndexPath(row: row, section: 0)
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "OrderBookListViewCell", for: index) as? OrderBookListViewCell else { return OrderBookListViewCell() }
+        cell.setData(with: data)
+        return cell
+      }.disposed(by: self.disposeBag)
+    
+    viewModel.cellData
+      .bind { orderBookListViewCellData in
+        let centerIndex = orderBookListViewCellData.count / 2
+        self.scrollToRow(at: IndexPath(row: centerIndex, section: .zero),
+                         at: .middle, animated: false)
+      }.disposed(by: self.disposeBag)
   }
 }
-

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
@@ -40,8 +40,13 @@ final class OrderBookListView: UITableView {
   func bind(viewModel: OrderBookListViewModelLogic) {
     viewModel.cellData
       .bind(to: self.rx.items) { tableView, row, data in
-        let index = IndexPath(row: row, section: 0)
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "OrderBookListViewCell", for: index) as? OrderBookListViewCell else { return OrderBookListViewCell() }
+        let indexPath = IndexPath(row: row, section: 0)
+        guard let cell = tableView.dequeueReusableCell(
+          withIdentifier: "OrderBookListViewCell",
+          for: indexPath
+        ) as? OrderBookListViewCell else {
+          return OrderBookListViewCell()
+        }
         cell.setData(with: data)
         return cell
       }.disposed(by: self.disposeBag)

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
@@ -39,7 +39,7 @@ final class OrderBookListView: UITableView {
   
   func bind(viewModel: OrderBookListViewModelLogic) {
     viewModel.cellData
-      .bind(to: self.rx.items) { tableView, row, data in
+      .drive(self.rx.items) { tableView, row, data in
         let indexPath = IndexPath(row: row, section: 0)
         guard let cell = tableView.dequeueReusableCell(
           withIdentifier: "OrderBookListViewCell",
@@ -50,9 +50,9 @@ final class OrderBookListView: UITableView {
         cell.setData(with: data)
         return cell
       }.disposed(by: self.disposeBag)
-    
+
     viewModel.cellData
-      .bind { orderBookListViewCellData in
+      .drive { orderBookListViewCellData in
         let centerIndex = orderBookListViewCellData.count / 2
         self.scrollToRow(at: IndexPath(row: centerIndex, section: .zero),
                          at: .middle, animated: false)

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCell.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCell.swift
@@ -42,17 +42,18 @@ final class OrderBookListViewCell: UITableViewCell {
   }
 
   private func attribute() {
-    self.askQuantityLabel.do {
+    self.bidQuantitylabel.do {
       $0.textAlignment = .left
       $0.textColor = .black
       $0.font = .systemFont(ofSize: 12)
     }
 
-    [self.bidQuantitylabel, self.priceLabel, self.priceChangedRatioLabel].forEach {
+    [self.askQuantityLabel, self.priceLabel, self.priceChangedRatioLabel].forEach {
       $0.textAlignment = .right
       $0.textColor = .black
       $0.font = .systemFont(ofSize: 12)
     }
+    self.selectionStyle = .none
   }
 
   private func layout() {
@@ -64,13 +65,13 @@ final class OrderBookListViewCell: UITableViewCell {
       self.priceStackView.addArrangedSubview($0)
     }
 
-    self.bidQuantitylabel.snp.makeConstraints {
+    self.askQuantityLabel.snp.makeConstraints {
       $0.leading.equalToSuperview()
       $0.top.bottom.equalToSuperview().inset(2)
       $0.width.equalToSuperview().multipliedBy(0.3)
     }
 
-    self.askQuantityLabel.snp.makeConstraints {
+    self.bidQuantitylabel.snp.makeConstraints {
       $0.leading.equalTo(self.priceStackView.snp.trailing).offset(2)
       $0.trailing.equalToSuperview()
       $0.top.bottom.equalToSuperview().inset(2)
@@ -79,7 +80,7 @@ final class OrderBookListViewCell: UITableViewCell {
 
     self.priceStackView.snp.makeConstraints {
       $0.top.bottom.equalToSuperview().inset(2)
-      $0.leading.equalTo(self.bidQuantitylabel.snp.trailing).offset(2)
+      $0.leading.equalTo(self.askQuantityLabel.snp.trailing).offset(2)
     }
 
     self.priceChangedRatioLabel.setContentHuggingPriority(.required, for: .horizontal)
@@ -90,13 +91,13 @@ final class OrderBookListViewCell: UITableViewCell {
     if data.orderBook == .ask {
       self.bidQuantitylabel.text = nil
       self.askQuantityLabel.text = data.orderQuantityText()
-      self.bidQuantitylabel.backgroundColor = nil
+      self.bidQuantitylabel.backgroundColor = .white
       self.askQuantityLabel.backgroundColor = .ask
       self.priceStackView.backgroundColor = .ask
     } else {
       self.askQuantityLabel.text = nil
       self.bidQuantitylabel.text = data.orderQuantityText()
-      self.askQuantityLabel.backgroundColor = nil
+      self.askQuantityLabel.backgroundColor = .white
       self.bidQuantitylabel.backgroundColor = .bid
       self.priceStackView.backgroundColor = .bid
     }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCell.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCell.swift
@@ -87,7 +87,7 @@ final class OrderBookListViewCell: UITableViewCell {
   }
 
   func setData(with data: OrderBookListViewCellData) {
-    if data.orderBook == .ask {
+    if data.orderBookCategory == .ask {
       self.bidQuantitylabel.text = nil
       self.askQuantityLabel.text = data.orderQuantityText()
       self.bidQuantitylabel.backgroundColor = .white

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCell.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCell.swift
@@ -53,7 +53,6 @@ final class OrderBookListViewCell: UITableViewCell {
       $0.textColor = .black
       $0.font = .systemFont(ofSize: 12)
     }
-    self.selectionStyle = .none
   }
 
   private func layout() {

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCellData.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCellData.swift
@@ -10,17 +10,18 @@ import Foundation
 import Then
 
 struct OrderBookListViewCellData: Equatable {
-  let orderBook: OrderBookCategory
-  let orderPrice: String
-  let orderQuantity: String
-  let priceChangedRatio: Double
+  let orderBookCategory: OrderBookCategory
+  let orderPrice: String?
+  let orderQuantity: String?
+  let priceChangedRatio: Double?
 }
 
 extension OrderBookListViewCellData {
   func priceChangedRatioText() -> NSAttributedString? {
-    let sign = self.priceChangedRatio.signText()
-    let color = UIColor.tickerColor(with: self.priceChangedRatio)
-    guard let priceChangedPercentage = String(abs(self.priceChangedRatio)).convertToPercentageText() else {
+    guard let priceChangedRatio = self.priceChangedRatio else { return nil }
+    let sign = priceChangedRatio.signText()
+    let color = UIColor.tickerColor(with: priceChangedRatio)
+    guard let priceChangedPercentage = String(abs(priceChangedRatio)).convertToPercentageText() else {
       return nil
     }
 
@@ -29,12 +30,17 @@ extension OrderBookListViewCellData {
   }
 
   func orderPriceText() -> NSAttributedString? {
-    guard let priceText = self.orderPrice.convertToDecimalText() else { return nil }
-    let color = UIColor.tickerColor(with: self.priceChangedRatio)
+    guard let orderPrice = self.orderPrice,
+          let priceChangedRatio = self.priceChangedRatio,
+          let priceText = orderPrice.convertToDecimalText() else {
+            return nil
+          }
+    let color = UIColor.tickerColor(with: priceChangedRatio)
     return priceText.convertToAttributedString(with: color)
   }
 
   func orderQuantityText() -> String? {
-    return self.orderQuantity.convertToDecimalText()
+    guard let orderQuantity = self.orderQuantity else { return nil }
+    return orderQuantity.convertToDecimalText()
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
@@ -11,23 +11,17 @@ import RxCocoa
 
 protocol OrderBookListViewModelLogic {
   var cellData: Driver<[OrderBookListViewCellData]> { get }
-  var askCellData: PublishSubject<[OrderBookListViewCellData]> { get }
-  var bidCellData: PublishSubject<[OrderBookListViewCellData]> { get }
+  var orderBookListViewCellData: PublishSubject<[OrderBookListViewCellData]> { get }
 }
 
 final class OrderBookListViewModel: OrderBookListViewModelLogic {
   let cellData: Driver<[OrderBookListViewCellData]>
-  let askCellData: PublishSubject<[OrderBookListViewCellData]>
-  let bidCellData: PublishSubject<[OrderBookListViewCellData]>
+  let orderBookListViewCellData: PublishSubject<[OrderBookListViewCellData]>
 
   init() {
-    self.askCellData = PublishSubject<[OrderBookListViewCellData]>()
-    self.bidCellData = PublishSubject<[OrderBookListViewCellData]>()
+    self.orderBookListViewCellData = PublishSubject<[OrderBookListViewCellData]>()
     
-    self.cellData = Observable.zip(
-      self.askCellData,
-      self.bidCellData
-    ).asDriver(onErrorJustReturn: ([], []))
-      .map { $0 + $1 }
+    self.cellData = self.orderBookListViewCellData
+      .asDriver(onErrorJustReturn: [])
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  OrderBookListViewModel.swift
+//  Cryptocurrency
+//
+//  Created by 이영우 on 2022/02/09.
+//
+
+import RxRelay
+
+protocol OrderBookListViewModelLogic {
+  var cellData: PublishRelay<[OrderBookListViewCellData]> { get }
+  var openingPrice: PublishRelay<Double?> { get }
+}
+
+final class OrderBookListViewModel: OrderBookListViewModelLogic {
+  let cellData = PublishRelay<[OrderBookListViewCellData]>()
+  let openingPrice = PublishRelay<Double?>()
+}

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
@@ -9,10 +9,10 @@ import RxRelay
 
 protocol OrderBookListViewModelLogic {
   var cellData: PublishRelay<[OrderBookListViewCellData]> { get }
-  var openingPrice: PublishRelay<Double?> { get }
+  var openingPrice: PublishRelay<Double> { get }
 }
 
 final class OrderBookListViewModel: OrderBookListViewModelLogic {
   let cellData = PublishRelay<[OrderBookListViewCellData]>()
-  let openingPrice = PublishRelay<Double?>()
+  let openingPrice = PublishRelay<Double>()
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
@@ -6,13 +6,28 @@
 //
 
 import RxRelay
+import RxSwift
+import RxCocoa
 
 protocol OrderBookListViewModelLogic {
-  var cellData: PublishRelay<[OrderBookListViewCellData]> { get }
-  var openingPrice: PublishRelay<Double> { get }
+  var cellData: Driver<[OrderBookListViewCellData]> { get }
+  var askCellData: PublishSubject<[OrderBookListViewCellData]> { get }
+  var bidCellData: PublishSubject<[OrderBookListViewCellData]> { get }
 }
 
 final class OrderBookListViewModel: OrderBookListViewModelLogic {
-  let cellData = PublishRelay<[OrderBookListViewCellData]>()
-  let openingPrice = PublishRelay<Double>()
+  let cellData: Driver<[OrderBookListViewCellData]>
+  let askCellData: PublishSubject<[OrderBookListViewCellData]>
+  let bidCellData: PublishSubject<[OrderBookListViewCellData]>
+
+  init() {
+    self.askCellData = PublishSubject<[OrderBookListViewCellData]>()
+    self.bidCellData = PublishSubject<[OrderBookListViewCellData]>()
+    
+    self.cellData = Observable.zip(
+      self.askCellData,
+      self.bidCellData
+    ).asDriver(onErrorJustReturn: ([], []))
+      .map { $0 + $1 }
+  }
 }

--- a/Cryptocurrency/Cryptocurrency/Entity/OrderBookResponse.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/OrderBookResponse.swift
@@ -57,7 +57,15 @@ struct OrderBookData: Decodable {
   }
 }
 
-struct OrderBook: Decodable {
+struct OrderBook: Decodable, Comparable {
+  static func < (lhs: OrderBook, rhs: OrderBook) -> Bool {
+    guard let lhsPrice = Double(lhs.price),
+          let rhsPrice = Double(rhs.price) else {
+            return false
+          }
+    return lhsPrice < rhsPrice
+  }
+  
   let quantity: String
   let price: String
 }

--- a/Cryptocurrency/Cryptocurrency/Entity/OrderBookResponse.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/OrderBookResponse.swift
@@ -41,15 +41,39 @@ import Foundation
 struct OrderBookResponse: Decodable {
   let status: String
   let data: OrderBookData
+
+  func orderBookListViewCellData(by closingPrice: Double) -> [OrderBookListViewCellData] {
+    let bids = self.data.bids.map { orderBook -> OrderBookListViewCellData? in
+      guard let orderPrice = Double(orderBook.price) else { return nil }
+      return OrderBookListViewCellData(
+        orderBook: .bid,
+        orderPrice: orderBook.price,
+        orderQuantity: orderBook.quantity,
+        priceChangedRatio: (orderPrice - closingPrice) / closingPrice
+      )
+    }.compactMap { $0 }
+
+    let asks = self.data.asks.map { orderBook -> OrderBookListViewCellData? in
+      guard let orderPrice = Double(orderBook.price) else { return nil }
+      return OrderBookListViewCellData(
+        orderBook: .ask,
+        orderPrice: orderBook.price,
+        orderQuantity: orderBook.quantity,
+        priceChangedRatio: (orderPrice - closingPrice) / closingPrice
+      )
+    }.compactMap { $0 }
+
+    return (bids + asks).sorted(by: { $0.orderPrice > $1.orderPrice })
+  }
 }
 
 struct OrderBookData: Decodable {
-  let timestamp: Int
+  let timestamp: String
   let orderCurrency: String
   let paymentCurrency: String
   let bids: [OrderBook]
   let asks: [OrderBook]
-  
+
   enum CodingKeys: String, CodingKey {
     case timestamp, bids, asks
     case orderCurrency = "order_currency"

--- a/Cryptocurrency/Cryptocurrency/Entity/OrderBookResponse.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/OrderBookResponse.swift
@@ -41,30 +41,6 @@ import Foundation
 struct OrderBookResponse: Decodable {
   let status: String
   let data: OrderBookData
-
-  func orderBookListViewCellData(by closingPrice: Double) -> [OrderBookListViewCellData] {
-    let bids = self.data.bids.map { orderBook -> OrderBookListViewCellData? in
-      guard let orderPrice = Double(orderBook.price) else { return nil }
-      return OrderBookListViewCellData(
-        orderBook: .bid,
-        orderPrice: orderBook.price,
-        orderQuantity: orderBook.quantity,
-        priceChangedRatio: (orderPrice - closingPrice) / closingPrice
-      )
-    }.compactMap { $0 }
-
-    let asks = self.data.asks.map { orderBook -> OrderBookListViewCellData? in
-      guard let orderPrice = Double(orderBook.price) else { return nil }
-      return OrderBookListViewCellData(
-        orderBook: .ask,
-        orderPrice: orderBook.price,
-        orderQuantity: orderBook.quantity,
-        priceChangedRatio: (orderPrice - closingPrice) / closingPrice
-      )
-    }.compactMap { $0 }
-
-    return (bids + asks).sorted(by: { $0.orderPrice > $1.orderPrice })
-  }
 }
 
 struct OrderBookData: Decodable {

--- a/Cryptocurrency/Cryptocurrency/Resources/Extensions/String + Ext.swift
+++ b/Cryptocurrency/Cryptocurrency/Resources/Extensions/String + Ext.swift
@@ -10,6 +10,7 @@ import UIKit
 extension String {
   func convertToDecimalText() -> String? {
     let numberFormatter = NumberFormatter()
+    numberFormatter.maximumFractionDigits = 4
     numberFormatter.numberStyle = .decimal
     
     guard let number = Double(self),

--- a/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
+++ b/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
@@ -94,39 +94,6 @@ final class CoinDetailUseCaseTests: XCTestCase {
     expect(chartData).to(beEmpty())
   }
   
-  func test_OrderBookResponse가_nil일_경우_orderBook_listview_cell_data를_빈_배열로_반환() {
-    //given
-    let response: OrderBookResponse? = nil
-    let openingPrice: Double? = 0.1
-    
-    //when
-    let orderBookListViewCellData = self.sut.orderBookListViewCellData(response: response, openingPrice: openingPrice)
-    
-    //then
-    expect(orderBookListViewCellData).to(beEmpty())
-  }
-  
-  func test_ClosingPrice가_nil일_경우_orderBook_listview_cell_data를_빈_배열로_반환() {
-    //given
-    let response: OrderBookResponse? = OrderBookResponse(
-      status: "0000",
-      data: OrderBookData(
-        timestamp: "1644491778626",
-        orderCurrency: "KRW",
-        paymentCurrency: "BTC",
-        bids: [OrderBook(quantity: "53910000", price: "0.3699")],
-        asks: [OrderBook(quantity: "53910000", price: "0.3699")]
-      )
-    )
-    let openingPrice: Double? = nil
-    
-    //when
-    let orderBookListViewCellData = self.sut.orderBookListViewCellData(response: response, openingPrice: openingPrice)
-    
-    //then
-    expect(orderBookListViewCellData).to(beEmpty())
-  }
-  
   func test_AllTickerResponse가_nil이_아닐_경우_ticker_data를_반환() {
     //given
     let response: AllTickerResponse = AllTickerResponse(
@@ -154,9 +121,9 @@ final class CoinDetailUseCaseTests: XCTestCase {
     
     //then
     expect(tickerData).toNot(beNil())
-    expect(tickerData!.data.currentPrice).to(equal("2000"))
-    expect(tickerData!.data.priceDifference).to(equal("10000"))
-    expect(tickerData!.data.priceChangedRatio).to(equal("1.0"))
+    expect(tickerData!.currentPrice).to(equal("2000"))
+    expect(tickerData!.priceDifference).to(equal("10000"))
+    expect(tickerData!.priceChangedRatio).to(equal("1.0"))
   }
   
   func test_CandleStickResponse가_nil이_아닐_경우_chart_data를_반환() {
@@ -189,7 +156,7 @@ final class CoinDetailUseCaseTests: XCTestCase {
   
   func test_OrderBookResponse가_nil이_아닐_경우_orderBook_listview_cell_data를_반환() {
     //given
-    let response: OrderBookResponse? = OrderBookResponse(
+    let response = OrderBookResponse(
       status: "0000",
       data: OrderBookData(
         timestamp: "1644491778626",
@@ -202,11 +169,11 @@ final class CoinDetailUseCaseTests: XCTestCase {
     let openingPrice: Double = 123.9
     
     //when
-    let orderBookListViewCellData = self.sut.orderBookListViewCellData(response: response, openingPrice: openingPrice)
+    let orderBookListViewCellData = self.sut.bidsCellData(with: response, openingPrice: openingPrice)
     
     //then
     expect(orderBookListViewCellData).toNot(beEmpty())
-    expect(orderBookListViewCellData[0].orderBook).to(equal(OrderBookCategory.bid))
+    expect(orderBookListViewCellData[0].orderBookCategory).to(equal(OrderBookCategory.bid))
     expect(orderBookListViewCellData[0].orderPrice).to(equal("0.3699"))
     expect(orderBookListViewCellData[0].orderQuantity).to(equal("53910000"))
   }

--- a/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
+++ b/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
@@ -32,7 +32,7 @@ final class CoinDetailUseCaseTests: XCTestCase {
     let result: Result<AllTickerResponse, APINetworkError> = .success(response)
     
     //when
-    let entity = self.sut.tickerResponse(result: result)
+    let entity = self.sut.response(result: result)
     
     //then
     expect(entity).notTo(beNil())
@@ -45,7 +45,27 @@ final class CoinDetailUseCaseTests: XCTestCase {
     let result: Result<CandleStickResponse, APINetworkError> = .success(response)
     
     //when
-    let entity = self.sut.candleStickResponse(result: result)
+    let entity = self.sut.response(result: result)
+    
+    //then
+    expect(entity).notTo(beNil())
+    expect(entity!.status).to(equal("0000"))
+  }
+
+  func test_OrderBookResponse_네트워크_결과물이_success일_경우_entity를_반환() {
+    //given
+    let orderBookData = OrderBookData(
+      timestamp: "1644491778626",
+      orderCurrency: "KRW",
+      paymentCurrency: "BTC",
+      bids: [OrderBook(quantity: "53910000", price: "0.3699")],
+      asks: [OrderBook(quantity: "53910000", price: "0.3699")]
+    )
+    let response = OrderBookResponse(status: "0000", data: orderBookData)
+    let result: Result<OrderBookResponse, APINetworkError> = .success(response)
+    
+    //when
+    let entity = self.sut.response(result: result)
     
     //then
     expect(entity).notTo(beNil())
@@ -72,6 +92,39 @@ final class CoinDetailUseCaseTests: XCTestCase {
     
     //then
     expect(chartData).to(beEmpty())
+  }
+  
+  func test_OrderBookResponse가_nil일_경우_orderBook_listview_cell_data를_빈_배열로_반환() {
+    //given
+    let response: OrderBookResponse? = nil
+    let openingPrice: Double? = 0.1
+    
+    //when
+    let orderBookListViewCellData = self.sut.orderBookListViewCellData(response: response, openingPrice: openingPrice)
+    
+    //then
+    expect(orderBookListViewCellData).to(beEmpty())
+  }
+  
+  func test_ClosingPrice가_nil일_경우_orderBook_listview_cell_data를_빈_배열로_반환() {
+    //given
+    let response: OrderBookResponse? = OrderBookResponse(
+      status: "0000",
+      data: OrderBookData(
+        timestamp: "1644491778626",
+        orderCurrency: "KRW",
+        paymentCurrency: "BTC",
+        bids: [OrderBook(quantity: "53910000", price: "0.3699")],
+        asks: [OrderBook(quantity: "53910000", price: "0.3699")]
+      )
+    )
+    let openingPrice: Double? = nil
+    
+    //when
+    let orderBookListViewCellData = self.sut.orderBookListViewCellData(response: response, openingPrice: openingPrice)
+    
+    //then
+    expect(orderBookListViewCellData).to(beEmpty())
   }
   
   func test_AllTickerResponse가_nil이_아닐_경우_ticker_data를_반환() {
@@ -101,9 +154,9 @@ final class CoinDetailUseCaseTests: XCTestCase {
     
     //then
     expect(tickerData).toNot(beNil())
-    expect(tickerData!.currentPrice).to(equal("2000"))
-    expect(tickerData!.priceDifference).to(equal("10000"))
-    expect(tickerData!.priceChangedRatio).to(equal("1.0"))
+    expect(tickerData!.data.currentPrice).to(equal("2000"))
+    expect(tickerData!.data.priceDifference).to(equal("10000"))
+    expect(tickerData!.data.priceChangedRatio).to(equal("1.0"))
   }
   
   func test_CandleStickResponse가_nil이_아닐_경우_chart_data를_반환() {
@@ -132,5 +185,29 @@ final class CoinDetailUseCaseTests: XCTestCase {
     expect(chartData[0].highPrice).to(equal(755000))
     expect(chartData[0].lowPrice).to(equal(737000))
     expect(chartData[0].exchangeVolume).to(equal(3.78))
+  }
+  
+  func test_OrderBookResponse가_nil이_아닐_경우_orderBook_listview_cell_data를_반환() {
+    //given
+    let response: OrderBookResponse? = OrderBookResponse(
+      status: "0000",
+      data: OrderBookData(
+        timestamp: "1644491778626",
+        orderCurrency: "KRW",
+        paymentCurrency: "BTC",
+        bids: [OrderBook(quantity: "53910000", price: "0.3699")],
+        asks: []
+      )
+    )
+    let openingPrice: Double = 123.9
+    
+    //when
+    let orderBookListViewCellData = self.sut.orderBookListViewCellData(response: response, openingPrice: openingPrice)
+    
+    //then
+    expect(orderBookListViewCellData).toNot(beEmpty())
+    expect(orderBookListViewCellData[0].orderBook).to(equal(OrderBookCategory.bid))
+    expect(orderBookListViewCellData[0].orderPrice).to(equal("0.3699"))
+    expect(orderBookListViewCellData[0].orderQuantity).to(equal("53910000"))
   }
 }

--- a/Cryptocurrency/CryptocurrencyTests/CoinDetail/Spy/NetworkManagerSpy.swift
+++ b/Cryptocurrency/CryptocurrencyTests/CoinDetail/Spy/NetworkManagerSpy.swift
@@ -14,7 +14,9 @@ struct NetworkManagerSpy: NetworkManagerLogic {
   
   var tickerResponseStub: Result<AllTickerResponse, APINetworkError>
   var candleStickResponseStub: Result<CandleStickResponse, APINetworkError>
-  
+  var orderBookResponseStub: Result<OrderBookResponse, APINetworkError> = .failure(.decodingError)
+  var transactionResponseStub: Result<TransactionHistoryResponse, APINetworkError> = .failure(.decodingError)
+
   func fetchTickerData(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency) -> Single<Result<AllTickerResponse, APINetworkError>> {
     return Observable.just(tickerResponseStub)
       .asSingle()
@@ -24,4 +26,14 @@ struct NetworkManagerSpy: NetworkManagerLogic {
     return Observable.just(candleStickResponseStub)
       .asSingle()
   }
+
+  func fetchOrderBookData(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency) -> Single<Result<OrderBookResponse, APINetworkError>> {
+    Observable.just(orderBookResponseStub)
+      .asSingle()
+  }
+
+  func fetchTransactionHistoryData(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency) -> Single<Result<TransactionHistoryResponse, APINetworkError>> {
+    Observable.just(transactionResponseStub)
+      .asSingle()
+  }  
 }


### PR DESCRIPTION
## 배경
- #59 
- 네트워킹을 수행할 수 있는 메서드를 UseCase에 구현하고, 호가창에 해당 정보들을 출력해요

## 수정사항
- OrderBookListView의 ViewModel을 생성
- OrderBookListViewCell에 잘못 작성되었던 UI 배치를 수정
- SegmentedControl을 통해 가상화폐 상세 화면 Content가 되는 View를 스위칭

## 테스트 방법

- 구동 테스트
<img src="https://user-images.githubusercontent.com/64566207/153405644-67d6f349-854e-468a-ae86-a1f31662bed8.png" width="350">

- 단위 테스트
UseCase에 새롭게 추가한 로직들을 테스트했어요

## 리뷰노트
- 화면전환시 Content가 올라오는 약간의 딜레이가 생기고 있어요. 직접 시뮬레이터를 통해 확인하시고, 조금 더 빠르게 동작할 수 있는 방법에 대해 이야기해보면 좋을 것 같아요