### PR TITLE
[#62] 시세정보를 나타낼 시세창의 UI를 구현하고, 화면에 시세정보를 출력해요

### DIFF
--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		C333E9D227B294DD004F92CE /* CoinDetailCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9D127B294DD004F92CE /* CoinDetailCategory.swift */; };
 		C333E9DC27B2C3F2004F92CE /* TransactionHistoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */; };
 		C333E9DE27B2C40F004F92CE /* OrderBookResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */; };
+		C3781FC427B7EEDF002586FA /* TransactionSheetViewCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */; };
 		C3D0B31527B50CBC005D4D61 /* OrderBookListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */; };
 		C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF4127A1902000A5E4BE /* String + Ext.swift */; };
 		C3D0EF6B27A7682400A5E4BE /* ChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF6A27A7682400A5E4BE /* ChartData.swift */; };
@@ -197,6 +198,7 @@
 		C333E9D127B294DD004F92CE /* CoinDetailCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailCategory.swift; sourceTree = "<group>"; };
 		C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryResponse.swift; sourceTree = "<group>"; };
 		C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookResponse.swift; sourceTree = "<group>"; };
+		C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewCellData.swift; sourceTree = "<group>"; };
 		C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookListViewModel.swift; sourceTree = "<group>"; };
 		C3D0EF4127A1902000A5E4BE /* String + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String + Ext.swift"; sourceTree = "<group>"; };
 		C3D0EF6A27A7682400A5E4BE /* ChartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartData.swift; sourceTree = "<group>"; };
@@ -647,6 +649,14 @@
 			path = CurrentPriceStatusView;
 			sourceTree = "<group>";
 		};
+		C3781FC227B7EEBC002586FA /* TransactionSheetView */ = {
+			isa = PBXGroup;
+			children = (
+				C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */,
+			);
+			path = TransactionSheetView;
+			sourceTree = "<group>";
+		};
 		C3D0EF6F27A777B500A5E4BE /* Module */ = {
 			isa = PBXGroup;
 			children = (
@@ -660,6 +670,7 @@
 		C3D0EF7827A7A40100A5E4BE /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				C3781FC227B7EEBC002586FA /* TransactionSheetView */,
 				C333E9C827B259CE004F92CE /* CurrentPriceStatusView */,
 				C329A8A827B15BCE00193A4D /* CoinDetailSegmentedCategoryView */,
 				C329A87B27AECD8300193A4D /* CoinChartView */,
@@ -952,6 +963,7 @@
 				4865371D27A69DB300BEBBB3 /* ExchangeSegmentedCategoryViewModel.swift in Sources */,
 				C329A8A227B14F8400193A4D /* OrderBookListView.swift in Sources */,
 				C333E9D227B294DD004F92CE /* CoinDetailCategory.swift in Sources */,
+				C3781FC427B7EEDF002586FA /* TransactionSheetViewCellData.swift in Sources */,
 				4885375C27A3D90E00BE00FD /* CurrentAssetCoordinator.swift in Sources */,
 				48256CD82799722E008F2AD1 /* ExchangeViewModel.swift in Sources */,
 				C329A80A27AB8DA600193A4D /* CandleStickResponse.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		C3781FC427B7EEDF002586FA /* TransactionSheetViewCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */; };
 		C3781FC627B7EF28002586FA /* TransactionSheetViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */; };
 		C3781FC827B7EF90002586FA /* TransactionSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC727B7EF90002586FA /* TransactionSheetView.swift */; };
+		C3781FCA27B7F262002586FA /* TransactionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC927B7F262002586FA /* TransactionSheetViewModel.swift */; };
 		C3D0B31527B50CBC005D4D61 /* OrderBookListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */; };
 		C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF4127A1902000A5E4BE /* String + Ext.swift */; };
 		C3D0EF6B27A7682400A5E4BE /* ChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF6A27A7682400A5E4BE /* ChartData.swift */; };
@@ -203,6 +204,7 @@
 		C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewCellData.swift; sourceTree = "<group>"; };
 		C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewCell.swift; sourceTree = "<group>"; };
 		C3781FC727B7EF90002586FA /* TransactionSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetView.swift; sourceTree = "<group>"; };
+		C3781FC927B7F262002586FA /* TransactionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewModel.swift; sourceTree = "<group>"; };
 		C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookListViewModel.swift; sourceTree = "<group>"; };
 		C3D0EF4127A1902000A5E4BE /* String + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String + Ext.swift"; sourceTree = "<group>"; };
 		C3D0EF6A27A7682400A5E4BE /* ChartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartData.swift; sourceTree = "<group>"; };
@@ -657,6 +659,7 @@
 			isa = PBXGroup;
 			children = (
 				C3781FC727B7EF90002586FA /* TransactionSheetView.swift */,
+				C3781FC927B7F262002586FA /* TransactionSheetViewModel.swift */,
 				C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */,
 				C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */,
 			);
@@ -979,6 +982,7 @@
 				489FB624279C43F10078AEE1 /* APINetworkError.swift in Sources */,
 				4881F4342797A29900472C90 /* TransactionViewController.swift in Sources */,
 				4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */,
+				C3781FCA27B7F262002586FA /* TransactionSheetViewModel.swift in Sources */,
 				48FDCFFC279541E2002F0050 /* AppDelegate.swift in Sources */,
 				4885375A27A3D88400BE00FD /* ProductServiceCoordinator.swift in Sources */,
 				C329A88627AECEC100193A4D /* CoinPriceData.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		C333E9DE27B2C40F004F92CE /* OrderBookResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */; };
 		C3781FC427B7EEDF002586FA /* TransactionSheetViewCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */; };
 		C3781FC627B7EF28002586FA /* TransactionSheetViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */; };
+		C3781FC827B7EF90002586FA /* TransactionSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC727B7EF90002586FA /* TransactionSheetView.swift */; };
 		C3D0B31527B50CBC005D4D61 /* OrderBookListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */; };
 		C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF4127A1902000A5E4BE /* String + Ext.swift */; };
 		C3D0EF6B27A7682400A5E4BE /* ChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF6A27A7682400A5E4BE /* ChartData.swift */; };
@@ -201,6 +202,7 @@
 		C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookResponse.swift; sourceTree = "<group>"; };
 		C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewCellData.swift; sourceTree = "<group>"; };
 		C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewCell.swift; sourceTree = "<group>"; };
+		C3781FC727B7EF90002586FA /* TransactionSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetView.swift; sourceTree = "<group>"; };
 		C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookListViewModel.swift; sourceTree = "<group>"; };
 		C3D0EF4127A1902000A5E4BE /* String + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String + Ext.swift"; sourceTree = "<group>"; };
 		C3D0EF6A27A7682400A5E4BE /* ChartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartData.swift; sourceTree = "<group>"; };
@@ -654,8 +656,9 @@
 		C3781FC227B7EEBC002586FA /* TransactionSheetView */ = {
 			isa = PBXGroup;
 			children = (
-				C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */,
+				C3781FC727B7EF90002586FA /* TransactionSheetView.swift */,
 				C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */,
+				C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */,
 			);
 			path = TransactionSheetView;
 			sourceTree = "<group>";
@@ -947,6 +950,7 @@
 				4885376027A3D92800BE00FD /* MoreOptionCoordinator.swift in Sources */,
 				C329A8AA27B15BE900193A4D /* CoinDetailSegmentedCategoryView.swift in Sources */,
 				C333E9D027B292B5004F92CE /* CoinDetailSegmentedCategoryViewModel.swift in Sources */,
+				C3781FC827B7EF90002586FA /* TransactionSheetView.swift in Sources */,
 				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
 				489FB61E279BF10B0078AEE1 /* NetworkRequestRouter.swift in Sources */,
 				C3D0B31527B50CBC005D4D61 /* OrderBookListViewModel.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		C333E9DC27B2C3F2004F92CE /* TransactionHistoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */; };
 		C333E9DE27B2C40F004F92CE /* OrderBookResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */; };
 		C3781FC427B7EEDF002586FA /* TransactionSheetViewCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */; };
+		C3781FC627B7EF28002586FA /* TransactionSheetViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */; };
 		C3D0B31527B50CBC005D4D61 /* OrderBookListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */; };
 		C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF4127A1902000A5E4BE /* String + Ext.swift */; };
 		C3D0EF6B27A7682400A5E4BE /* ChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF6A27A7682400A5E4BE /* ChartData.swift */; };
@@ -199,6 +200,7 @@
 		C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryResponse.swift; sourceTree = "<group>"; };
 		C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookResponse.swift; sourceTree = "<group>"; };
 		C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewCellData.swift; sourceTree = "<group>"; };
+		C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewCell.swift; sourceTree = "<group>"; };
 		C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookListViewModel.swift; sourceTree = "<group>"; };
 		C3D0EF4127A1902000A5E4BE /* String + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String + Ext.swift"; sourceTree = "<group>"; };
 		C3D0EF6A27A7682400A5E4BE /* ChartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartData.swift; sourceTree = "<group>"; };
@@ -653,6 +655,7 @@
 			isa = PBXGroup;
 			children = (
 				C3781FC327B7EEDF002586FA /* TransactionSheetViewCellData.swift */,
+				C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */,
 			);
 			path = TransactionSheetView;
 			sourceTree = "<group>";
@@ -985,6 +988,7 @@
 				48B60E4C279FBF3B000534EC /* TickerResponse.swift in Sources */,
 				4881F4362797A2B800472C90 /* MoreOptionViewController.swift in Sources */,
 				C329A89927B0C59500193A4D /* PaddingLabel.swift in Sources */,
+				C3781FC627B7EF28002586FA /* TransactionSheetViewCell.swift in Sources */,
 				C333E9CA27B259F1004F92CE /* CurrentPriceStatusView.swift in Sources */,
 				4885375627A3CFF800BE00FD /* AppCoordinator.swift in Sources */,
 				4885376327A40E3600BE00FD /* CoinDetailViewController.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailCategory.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailCategory.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 enum CoinDetailCategory: Int, CaseIterable {
-  case orderBook = 0
-  case chart = 1
-  case transactionHistory = 2
+  case orderBook
+  case chart
+  case transactionHistory
   
   static func findCategory(with index: Int) -> Self {
     guard let category = CoinDetailCategory.allCases

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
@@ -124,7 +124,7 @@ final class CoinDetailViewController: UIViewController {
     self.coinChartView.bind(viewModel: self.coinDetailViewModel.coinChartViewModel)
     self.currentPriceStatusView.bind(viewModel: self.coinDetailViewModel.currentPriceStatusViewModel)
     self.orderBookListView.bind(viewModel: self.coinDetailViewModel.orderBookListViewModel)
-    self.transactionSheetView.bind(viewModel: self.coinDetailViewModel.transactionSheetViewModel)
+    self.transactionSheetView.bind(transactionSheetViewModel: self.coinDetailViewModel.transactionSheetViewModel)
 
     self.timeUnitChangeButton.rx.tap
       .bind(to: self.coinDetailViewModel.tapSelectTimeUnitButton)

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewController.swift
@@ -33,6 +33,7 @@ final class CoinDetailViewController: UIViewController {
   private let timeUnitChangeButton: UIButton
   private let coinChartView: CoinChartView
   private let currentPriceStatusView: CurrentPriceStatusView
+  private let transactionSheetView: TransactionSheetView
   
   
   // MARK: Initializers
@@ -47,6 +48,7 @@ final class CoinDetailViewController: UIViewController {
     self.timeUnitChangeButton = UIButton()
     self.coinChartView = CoinChartView()
     self.currentPriceStatusView = CurrentPriceStatusView()
+    self.transactionSheetView = TransactionSheetView()
     
     super.init(nibName: nil, bundle: nil)
   }
@@ -68,7 +70,8 @@ final class CoinDetailViewController: UIViewController {
      self.coinDetailSegmentedCategoryView,
      self.timeUnitChangeButton,
      self.currentPriceStatusView,
-     self.orderBookListView].forEach { self.view.addSubview($0) }
+     self.orderBookListView,
+     self.transactionSheetView].forEach { self.view.addSubview($0) }
     
     self.currentPriceStatusView.snp.makeConstraints {
       $0.leading.top.equalTo(self.view.safeAreaLayoutGuide).inset(10)
@@ -89,7 +92,12 @@ final class CoinDetailViewController: UIViewController {
       $0.top.equalTo(self.coinDetailSegmentedCategoryView.snp.bottom).offset(10)
       $0.bottom.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
     }
-    
+
+    self.transactionSheetView.snp.makeConstraints {
+      $0.top.equalTo(self.coinDetailSegmentedCategoryView.snp.bottom).offset(10)
+      $0.bottom.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
+    }
+
     self.timeUnitChangeButton.snp.makeConstraints {
       $0.trailing.equalToSuperview().inset(10)
       $0.bottom.equalTo(self.coinChartView.snp.top)
@@ -116,6 +124,7 @@ final class CoinDetailViewController: UIViewController {
     self.coinChartView.bind(viewModel: self.coinDetailViewModel.coinChartViewModel)
     self.currentPriceStatusView.bind(viewModel: self.coinDetailViewModel.currentPriceStatusViewModel)
     self.orderBookListView.bind(viewModel: self.coinDetailViewModel.orderBookListViewModel)
+    self.transactionSheetView.bind(viewModel: self.coinDetailViewModel.transactionSheetViewModel)
 
     self.timeUnitChangeButton.rx.tap
       .bind(to: self.coinDetailViewModel.tapSelectTimeUnitButton)
@@ -137,12 +146,17 @@ final class CoinDetailViewController: UIViewController {
       self.orderBookListView.isHidden = false
       self.coinChartView.isHidden = true
       self.timeUnitChangeButton.isHidden = true
+      self.transactionSheetView.isHidden = true
     case .chart:
       self.orderBookListView.isHidden = true
       self.coinChartView.isHidden = false
       self.timeUnitChangeButton.isHidden = false
+      self.transactionSheetView.isHidden = true
     case .transactionHistory:
-      break
+      self.orderBookListView.isHidden = true
+      self.coinChartView.isHidden = true
+      self.timeUnitChangeButton.isHidden = true
+      self.transactionSheetView.isHidden = false
     }
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -17,6 +17,7 @@ final class CoinDetailViewModel {
   let coinChartViewModel = CoinChartViewModel()
   let currentPriceStatusViewModel = CurrentPriceStatusViewModel()
   let coinDetailSegmentedCategoryViewModel = CoinDetailSegmentedCategoryViewModel()
+  let transactionSheetViewModel = TransactionSheetViewModel()
   let orderBookListViewModel = OrderBookListViewModel()
   let openingPrice = PublishRelay<Double>()
   var coinDetailCoordinator: CoinDetailCoordinator?
@@ -91,5 +92,19 @@ final class CoinDetailViewModel {
     }
     .bind(to: self.orderBookListViewModel.orderBookListViewCellData)
     .disposed(by: self.disposeBag)
+
+    let transactionHistoryResult = useCase.fetchTransactionHistory(orderCurrency: orderCurrency,
+                                                                   paymentCurrency: paymentCurrency)
+
+    let transactionHistoryResponse = transactionHistoryResult
+      .map(useCase.response)
+      .filter { $0 != nil }
+      .map { $0! }
+
+    transactionHistoryResponse
+      .map(useCase.transactionSheetViewCellData)
+      .asObservable()
+      .bind(to: self.transactionSheetViewModel.transactionSheetViewCellData)
+      .disposed(by: self.disposeBag)
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -21,8 +21,10 @@ final class CoinDetailViewModel {
   let orderBookListViewModel = OrderBookListViewModel()
   let openingPrice = PublishRelay<Double>()
   var coinDetailCoordinator: CoinDetailCoordinator?
-
   private let disposeBag = DisposeBag()
+
+
+  // MARK: Initializer
 
   init(useCase: CoinDetailUseCaseLogic = CoinDetailUseCase(),
        orderCurrency: OrderCurrency,

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CoinChartView/CoinChartView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CoinChartView/CoinChartView.swift
@@ -46,7 +46,10 @@ final class CoinChartView: CandleStickChartView {
     self.dragYEnabled = false
     self.delegate = self
   }
-  
+
+
+  // MARK: Binding
+
   func bind(viewModel: CoinChartViewModelLogic) {
     viewModel.chartData
       .bind { chartData in

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CoinChartView/CoinChartViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CoinChartView/CoinChartViewModel.swift
@@ -14,5 +14,8 @@ protocol CoinChartViewModelLogic {
 }
 
 final class CoinChartViewModel: CoinChartViewModelLogic {
+
+  // MARK: Properties
+
   let chartData = PublishRelay<[ChartData]>()
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CoinDetailSegmentedCategoryView/CoinDetailSegmentedCategoryView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CoinDetailSegmentedCategoryView/CoinDetailSegmentedCategoryView.swift
@@ -28,7 +28,7 @@ final class CoinDetailSegmentedCategoryView: SegmentedCategoryView {
   }
   
   
-  // MARK: Bind
+  // MARK: Binding
   
   func bind(viewModel: CoinDetailSegmentedCategoryViewModelLogic) {
     self.segmentedControl.rx.selectedSegmentIndex

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CoinDetailSegmentedCategoryView/CoinDetailSegmentedCategoryViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CoinDetailSegmentedCategoryView/CoinDetailSegmentedCategoryViewModel.swift
@@ -14,5 +14,8 @@ protocol CoinDetailSegmentedCategoryViewModelLogic {
 }
 
 final class CoinDetailSegmentedCategoryViewModel: CoinDetailSegmentedCategoryViewModelLogic {
+
+  // MARK: Properties
+
   let category = BehaviorRelay<CoinDetailCategory>(value: .orderBook)
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusViewModel.swift
@@ -12,5 +12,8 @@ protocol CurrentPriceStatusViewModelLogic {
 }
 
 final class CurrentPriceStatusViewModel: CurrentPriceStatusViewModelLogic {
+
+  // MARK: Properties
+
   let coinPriceData = PublishRelay<CoinPriceData>()
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookCategory.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookCategory.swift
@@ -7,7 +7,14 @@
 
 import Foundation
 
-enum OrderBookCategory {
+enum OrderBookCategory: String, CaseIterable {
   case bid
   case ask
+
+  static func findOrderBookCategory(with text: String) -> Self? {
+    guard let orderBookCategory = OrderBookCategory.allCases
+            .filter({ $0.rawValue == text })
+            .first else { return .bid }
+    return orderBookCategory
+  }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
@@ -36,7 +36,10 @@ final class OrderBookListView: UITableView {
     self.allowsSelection = false
     self.rowHeight = 40
   }
+
   
+  // MARK: Binding
+
   func bind(viewModel: OrderBookListViewModelLogic) {
     viewModel.cellData
       .drive(self.rx.items) { tableView, row, data in

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
@@ -15,8 +15,14 @@ protocol OrderBookListViewModelLogic {
 }
 
 final class OrderBookListViewModel: OrderBookListViewModelLogic {
+
+  // MARK: Properties
+
   let cellData: Driver<[OrderBookListViewCellData]>
   let orderBookListViewCellData: PublishSubject<[OrderBookListViewCellData]>
+
+
+  // MARK: Initialzier
 
   init() {
     self.orderBookListViewCellData = PublishSubject<[OrderBookListViewCellData]>()

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetView.swift
@@ -1,0 +1,92 @@
+//
+//  TransactionHistorySheetView.swift
+//  Cryptocurrency
+//
+//  Created by 이영우 on 2022/02/12.
+//
+
+import UIKit
+
+import RxSwift
+import Then
+
+final class TransactionSheetView: UIView {
+  
+  // MARK: Properties
+  
+  private let transactionListView = UITableView()
+  private let timeCategoryLabel = UILabel()
+  private let priceCategoryLabel = UILabel()
+  private let transactionCategoryLabel = UILabel()
+  
+  private let disposeBag = DisposeBag()
+  
+  init() {
+    super.init(frame: .zero)
+    
+    self.layout()
+    self.attribute()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func layout() {
+    [self.transactionListView,
+     self.timeCategoryLabel,
+     self.priceCategoryLabel,
+     self.transactionCategoryLabel].forEach {
+      self.addSubview($0)
+    }
+    
+    self.timeCategoryLabel.snp.makeConstraints {
+      $0.leading.top.equalToSuperview()
+      $0.width.equalTo(80)
+      $0.height.equalTo(30)
+    }
+    
+    self.priceCategoryLabel.snp.makeConstraints {
+      $0.top.equalToSuperview()
+      $0.leading.equalTo(self.timeCategoryLabel.snp.trailing)
+      $0.width.equalTo(self.transactionCategoryLabel)
+      $0.height.equalTo(self.timeCategoryLabel)
+    }
+    
+    self.transactionCategoryLabel.snp.makeConstraints {
+      $0.top.trailing.equalToSuperview()
+      $0.leading.equalTo(self.priceCategoryLabel.snp.trailing)
+      $0.height.equalTo(self.timeCategoryLabel)
+    }
+    
+    self.transactionListView.snp.makeConstraints {
+      $0.top.equalTo(timeCategoryLabel.snp.bottom)
+      $0.leading.trailing.bottom.equalToSuperview()
+    }
+  }
+  
+  private func attribute() {
+    self.transactionListView.do {
+      $0.register(TransactionSheetViewCell.self, forCellReuseIdentifier: "TransactionSheetViewCell")
+      $0.allowsSelection = false
+    }
+    
+    self.timeCategoryLabel.text = "시간"
+    self.priceCategoryLabel.text = "가격"
+    self.transactionCategoryLabel.text = "체결량"
+
+    [self.timeCategoryLabel, self.priceCategoryLabel, self.transactionCategoryLabel].forEach {
+      $0.textAlignment = .center
+      $0.layer.borderColor = UIColor.lightGray.cgColor
+      $0.layer.borderWidth = 0.4
+      $0.font = .systemFont(ofSize: 12)
+    }
+  }
+  
+  
+  // MARK: Bind
+  
+  func bind() {
+    // TODO: TransactionSheetViewModel을 매개변수로 받아와 Binding
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import RxCocoa
 import RxSwift
 import Then
 
@@ -86,7 +87,18 @@ final class TransactionSheetView: UIView {
   
   // MARK: Bind
   
-  func bind() {
-    // TODO: TransactionSheetViewModel을 매개변수로 받아와 Binding
+  func bind(viewModel: TransactionSheetViewModelLogic) {
+    viewModel.cellData
+      .drive(self.transactionListView.rx.items) { tableView, row, data in
+        let indexPath = IndexPath(row: row, section: 0)
+        guard let cell = tableView.dequeueReusableCell(
+          withIdentifier: "TransactionSheetViewCell",
+          for: indexPath
+        ) as? TransactionSheetViewCell else {
+          return TransactionSheetViewCell()
+        }
+        cell.setData(with: data)
+        return cell
+      }.disposed(by: self.disposeBag)
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetView.swift
@@ -19,8 +19,10 @@ final class TransactionSheetView: UIView {
   private let timeCategoryLabel = UILabel()
   private let priceCategoryLabel = UILabel()
   private let transactionCategoryLabel = UILabel()
-  
   private let disposeBag = DisposeBag()
+  
+  
+  // MARK: Initializer
   
   init() {
     super.init(frame: .zero)
@@ -86,10 +88,10 @@ final class TransactionSheetView: UIView {
   }
   
   
-  // MARK: Bind
+  // MARK: Binding
   
-  func bind(viewModel: TransactionSheetViewModelLogic) {
-    viewModel.cellData
+  func bind(transactionSheetViewModel: TransactionSheetViewModelLogic) {
+    transactionSheetViewModel.cellData
       .drive(self.transactionListView.rx.items) { tableView, row, data in
         let indexPath = IndexPath(row: row, section: 0)
         guard let cell = tableView.dequeueReusableCell(

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetView.swift
@@ -70,6 +70,7 @@ final class TransactionSheetView: UIView {
     self.transactionListView.do {
       $0.register(TransactionSheetViewCell.self, forCellReuseIdentifier: "TransactionSheetViewCell")
       $0.allowsSelection = false
+      $0.rowHeight = 40
     }
     
     self.timeCategoryLabel.text = "시간"

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCell.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCell.swift
@@ -1,0 +1,82 @@
+//
+//  TransactionSheetViewCell.swift
+//  Cryptocurrency
+//
+//  Created by 이영우 on 2022/02/12.
+//
+
+import UIKit
+
+import SnapKit
+
+final class TransactionSheetViewCell: UITableViewCell {
+
+  // MARK: Properties
+
+  private let timeLabel: PaddingLabel
+  private let priceLabel: PaddingLabel
+  private let volumeLabel: PaddingLabel
+
+
+  // MARK: Initializer
+
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    let padding = UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
+    self.timeLabel = PaddingLabel(padding: padding)
+    self.priceLabel = PaddingLabel(padding: padding)
+    self.volumeLabel = PaddingLabel(padding: padding)
+    
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    
+    self.layout()
+    self.attribute()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func layout() {
+    [self.timeLabel, self.priceLabel, self.volumeLabel].forEach {
+      self.contentView.addSubview($0)
+    }
+    
+    self.timeLabel.snp.makeConstraints {
+      $0.leading.top.bottom.equalToSuperview()
+      $0.width.equalTo(80)
+    }
+    
+    self.priceLabel.snp.makeConstraints {
+      $0.top.bottom.equalToSuperview()
+      $0.leading.equalTo(self.timeLabel.snp.trailing)
+      $0.width.equalTo(self.volumeLabel)
+    }
+    
+    self.volumeLabel.snp.makeConstraints {
+      $0.top.bottom.trailing.equalToSuperview()
+      $0.leading.equalTo(self.priceLabel.snp.trailing)
+    }
+    
+    self.timeLabel.setContentHuggingPriority(.required, for: .horizontal)
+    self.timeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+  }
+
+  private func attribute() {
+    [self.timeLabel, self.priceLabel, self.volumeLabel].forEach {
+      $0.layer.borderColor = UIColor.lightGray.cgColor
+      $0.layer.borderWidth = 0.3
+      $0.font = .systemFont(ofSize: 12)
+      $0.textColor = .black
+    }
+
+    self.timeLabel.textAlignment = .center
+    self.priceLabel.textAlignment = .right
+    self.volumeLabel.textAlignment = .right
+  }
+
+  func setData(with data: TransactionSheetViewCellData) {
+    self.timeLabel.text = data.dateText
+    self.priceLabel.attributedText = data.priceText()
+    self.volumeLabel.attributedText = data.volumeText()
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCell.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCell.swift
@@ -74,6 +74,9 @@ final class TransactionSheetViewCell: UITableViewCell {
     self.volumeLabel.textAlignment = .right
   }
 
+
+  // MARK: Set CellData
+
   func setData(with data: TransactionSheetViewCellData) {
     self.timeLabel.text = data.dateText
     self.priceLabel.attributedText = data.priceText()

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCellData.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCellData.swift
@@ -16,7 +16,9 @@ struct TransactionSheetViewCellData {
 
 extension TransactionSheetViewCellData {
   func priceText() -> NSAttributedString? {
-    let color = self.orderBookCategory == .ask ? UIColor.red : UIColor.blue
+    let askTextColor = UIColor.red.withAlphaComponent(0.8)
+    let bidTextColor = UIColor.blue.withAlphaComponent(0.8)
+    let color = self.orderBookCategory == .ask ? askTextColor : bidTextColor
     guard let decimalText = self.transactionPrice.convertToDecimalText() else {
       return nil
     }
@@ -24,7 +26,9 @@ extension TransactionSheetViewCellData {
   }
 
   func volumeText() -> NSAttributedString? {
-    let color = self.orderBookCategory == .ask ? UIColor.red : UIColor.blue
+    let askTextColor = UIColor.red.withAlphaComponent(0.8)
+    let bidTextColor = UIColor.blue.withAlphaComponent(0.8)
+    let color = self.orderBookCategory == .ask ? askTextColor : bidTextColor
     let numberFormatter = NumberFormatter()
     numberFormatter.minimumFractionDigits = 4
     numberFormatter.maximumFractionDigits = 4

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCellData.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCellData.swift
@@ -18,7 +18,7 @@ extension TransactionSheetViewCellData {
   func priceText() -> NSAttributedString? {
     let askTextColor = UIColor.red.withAlphaComponent(0.8)
     let bidTextColor = UIColor.blue.withAlphaComponent(0.8)
-    let color = self.orderBookCategory == .ask ? askTextColor : bidTextColor
+    let color = (self.orderBookCategory) == .ask ? askTextColor : bidTextColor
     guard let decimalText = self.transactionPrice.convertToDecimalText() else {
       return nil
     }
@@ -28,7 +28,7 @@ extension TransactionSheetViewCellData {
   func volumeText() -> NSAttributedString? {
     let askTextColor = UIColor.red.withAlphaComponent(0.8)
     let bidTextColor = UIColor.blue.withAlphaComponent(0.8)
-    let color = self.orderBookCategory == .ask ? askTextColor : bidTextColor
+    let color = (self.orderBookCategory == .ask) ? askTextColor : bidTextColor
     let numberFormatter = NumberFormatter()
     numberFormatter.minimumFractionDigits = 4
     numberFormatter.maximumFractionDigits = 4

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCellData.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCellData.swift
@@ -1,0 +1,35 @@
+//
+//  TransactionSheetViewCellData.swift
+//  Cryptocurrency
+//
+//  Created by 이영우 on 2022/02/12.
+//
+
+import UIKit
+
+struct TransactionSheetViewCellData {
+  let orderBookCategory: OrderBookCategory
+  let transactionPrice: String
+  let dateText: String
+  let volume: Double
+}
+
+extension TransactionSheetViewCellData {
+  func priceText() -> NSAttributedString? {
+    let color = self.orderBookCategory == .ask ? UIColor.red : UIColor.blue
+    guard let decimalText = self.transactionPrice.convertToDecimalText() else {
+      return nil
+    }
+    return decimalText.convertToAttributedString(with: color)
+  }
+
+  func volumeText() -> NSAttributedString? {
+    let color = self.orderBookCategory == .ask ? UIColor.red : UIColor.blue
+    let numberFormatter = NumberFormatter()
+    numberFormatter.minimumFractionDigits = 4
+    numberFormatter.maximumFractionDigits = 4
+    numberFormatter.numberStyle = .decimal
+    let text = numberFormatter.string(for: self.volume)
+    return text?.convertToAttributedString(with: color)
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  TransactionSheetViewModel.swift
+//  Cryptocurrency
+//
+//  Created by 이영우 on 2022/02/12.
+//
+
+import RxCocoa
+import RxSwift
+
+protocol TransactionSheetViewModelLogic {
+  var transactionSheetViewCellData: PublishSubject<[TransactionSheetViewCellData]> { get }
+  var cellData: Driver<[TransactionSheetViewCellData]> { get }
+}
+
+final class TransactionSheetViewModel: TransactionSheetViewModelLogic {
+  let transactionSheetViewCellData: PublishSubject<[TransactionSheetViewCellData]>
+  let cellData: Driver<[TransactionSheetViewCellData]>
+  
+  init() {
+    self.transactionSheetViewCellData = PublishSubject<[TransactionSheetViewCellData]>()
+
+    self.cellData = self.transactionSheetViewCellData
+      .asDriver(onErrorJustReturn: [])
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewModel.swift
@@ -14,9 +14,15 @@ protocol TransactionSheetViewModelLogic {
 }
 
 final class TransactionSheetViewModel: TransactionSheetViewModelLogic {
+
+  // MARK: Properties
+
   let transactionSheetViewCellData: PublishSubject<[TransactionSheetViewCellData]>
   let cellData: Driver<[TransactionSheetViewCellData]>
-  
+
+
+  // MARK: Initializer
+
   init() {
     self.transactionSheetViewCellData = PublishSubject<[TransactionSheetViewCellData]>()
 

--- a/Cryptocurrency/Cryptocurrency/Resources/Base.lproj/LaunchScreen.storyboard
+++ b/Cryptocurrency/Cryptocurrency/Resources/Base.lproj/LaunchScreen.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,7 +16,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -25,9 +24,4 @@
             <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
+++ b/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
@@ -72,6 +72,26 @@ final class CoinDetailUseCaseTests: XCTestCase {
     expect(entity!.status).to(equal("0000"))
   }
   
+  func test_TransactionHistoryResponse_네트워크_결과물이_success일_경우_entity를_반환() {
+    //given
+    let transactionData = TransactionHistoryData(
+      transactionDate: "2022-02-13 20:47:52",
+      type: "bid",
+      unitsTraded: "339521.5664",
+      price: "0.0027",
+      total: "916"
+    )
+    let response = TransactionHistoryResponse(status: "0000", data: [transactionData])
+    let result: Result<TransactionHistoryResponse, APINetworkError> = .success(response)
+    
+    //when
+    let entity = self.sut.response(result: result)
+    
+    //then
+    expect(entity).notTo(beNil())
+    expect(entity!.status).to(equal("0000"))
+  }
+
   func test_AllTickerResponse가_nil일_경우_ticker_data를_nil로_반환() {
     //given
     let response: AllTickerResponse? = nil
@@ -169,7 +189,9 @@ final class CoinDetailUseCaseTests: XCTestCase {
     let openingPrice: Double = 123.9
     
     //when
-    let orderBookListViewCellData = self.sut.bidsCellData(with: response, openingPrice: openingPrice)
+    let orderBookListViewCellData = self.sut.orderBookListViewCellData(with: response,
+                                                                       category: .bid,
+                                                                       openingPrice: openingPrice)
     
     //then
     expect(orderBookListViewCellData).toNot(beEmpty())


### PR DESCRIPTION
## 배경
- #62 
- 시세정보를 나타내기 위한 UI 컴포넌트를 구현하고, NetworkManager를 통해서 네트워킹을 수행하고 해당 정보를 시세창을 통해서 출력해요

## 수정사항
- 시세정보창인 TransactionSheetView 타입을 생성하고 구현해요
- 시세정보창에서 사용할 Cell인 TransactionSheetViewCell 을 생성하고 구현해요
- Cell의 Data인 TransactionSheetViewCellData를 생성하고 구현해요

## 테스트 방법
- 구동테스트
<img src="https://user-images.githubusercontent.com/64566207/153718755-7f7dda67-ea6c-4178-9874-ba47409c6829.png" width="350">

## 리뷰노트
- 현재 SegmentedControl의 경우 isHidden을 해줄 UI Component들을 지정해주는 것 이외에는 동작이 없어요. SegmentedControl이 눌러질 경우에 시세창, 호가창의 경우는 API를 통해서 재요청되도록 변경할 예정이에요
- 이후 작업에서 메모리 누수가 있는지 점검하며, Socket을 연결할 예정이에요
