### PR TITLE
[#65] 가상화폐 상세화면에 소켓을 연결하여 실시간 업데이트를 수행해요

### DIFF
--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		C3781FC627B7EF28002586FA /* TransactionSheetViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */; };
 		C3781FC827B7EF90002586FA /* TransactionSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC727B7EF90002586FA /* TransactionSheetView.swift */; };
 		C3781FCA27B7F262002586FA /* TransactionSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3781FC927B7F262002586FA /* TransactionSheetViewModel.swift */; };
+		C3C3DD6E27BF519C00052C5E /* SocketOrderBookResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C3DD6D27BF519C00052C5E /* SocketOrderBookResponse.swift */; };
+		C3C3DD7027BF51DC00052C5E /* SocketTransactionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C3DD6F27BF51DC00052C5E /* SocketTransactionResponse.swift */; };
 		C3D0B31527B50CBC005D4D61 /* OrderBookListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */; };
 		C3D0EF4227A1902100A5E4BE /* String + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF4127A1902000A5E4BE /* String + Ext.swift */; };
 		C3D0EF6B27A7682400A5E4BE /* ChartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D0EF6A27A7682400A5E4BE /* ChartData.swift */; };
@@ -213,6 +215,8 @@
 		C3781FC527B7EF28002586FA /* TransactionSheetViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewCell.swift; sourceTree = "<group>"; };
 		C3781FC727B7EF90002586FA /* TransactionSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetView.swift; sourceTree = "<group>"; };
 		C3781FC927B7F262002586FA /* TransactionSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionSheetViewModel.swift; sourceTree = "<group>"; };
+		C3C3DD6D27BF519C00052C5E /* SocketOrderBookResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketOrderBookResponse.swift; sourceTree = "<group>"; };
+		C3C3DD6F27BF51DC00052C5E /* SocketTransactionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketTransactionResponse.swift; sourceTree = "<group>"; };
 		C3D0B31427B50CBC005D4D61 /* OrderBookListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBookListViewModel.swift; sourceTree = "<group>"; };
 		C3D0EF4127A1902000A5E4BE /* String + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String + Ext.swift"; sourceTree = "<group>"; };
 		C3D0EF6A27A7682400A5E4BE /* ChartData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartData.swift; sourceTree = "<group>"; };
@@ -313,13 +317,15 @@
 		48256CE827997415008F2AD1 /* Entity */ = {
 			isa = PBXGroup;
 			children = (
-				488F9E7B279BA68E0021A545 /* AllTickerResponse.swift */,
 				4882FA6E279D288100A25880 /* Currency.swift */,
 				48B60E4B279FBF3B000534EC /* TickerResponse.swift */,
-				C329A80927AB8DA600193A4D /* CandleStickResponse.swift */,
-				48A49ECE27A9772000DF5124 /* SocketTickerResponse.swift */,
+				488F9E7B279BA68E0021A545 /* AllTickerResponse.swift */,
 				C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */,
+				C329A80927AB8DA600193A4D /* CandleStickResponse.swift */,
 				C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */,
+				48A49ECE27A9772000DF5124 /* SocketTickerResponse.swift */,
+				C3C3DD6D27BF519C00052C5E /* SocketOrderBookResponse.swift */,
+				C3C3DD6F27BF51DC00052C5E /* SocketTransactionResponse.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -1004,6 +1010,7 @@
 				48D6C3D727B69E79000CB5AB /* CoinListSortViewModel.swift in Sources */,
 				4881F42927979E6600472C90 /* ExchangeViewController.swift in Sources */,
 				C3781FCA27B7F262002586FA /* TransactionSheetViewModel.swift in Sources */,
+				C3C3DD6E27BF519C00052C5E /* SocketOrderBookResponse.swift in Sources */,
 				48FDCFFC279541E2002F0050 /* AppDelegate.swift in Sources */,
 				4885375A27A3D88400BE00FD /* ProductServiceCoordinator.swift in Sources */,
 				C329A88627AECEC100193A4D /* CoinPriceData.swift in Sources */,
@@ -1038,6 +1045,7 @@
 				B4A8E11A279D286200A2BFCD /* UISegmentedControl + Ext.swift in Sources */,
 				B4A8E118279BF15D00A2BFCD /* SegmentedCategoryView.swift in Sources */,
 				48AD306F27A974F100278D7A /* WebSocketManager.swift in Sources */,
+				C3C3DD7027BF51DC00052C5E /* SocketTransactionResponse.swift in Sources */,
 				48256CE227997298008F2AD1 /* CoinListViewModel.swift in Sources */,
 				C3D0EF7A27A7A42100A5E4BE /* TimeUnitBottomSheet.swift in Sources */,
 				C3D0EF9C27A8AC1F00A5E4BE /* CoinDetailViewModel.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailCoordinator.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailCoordinator.swift
@@ -40,8 +40,38 @@ final class CoinDetailCoordinator: Coordinator {
       $0.coinDetailViewModel.coinDetailCoordinator = self
     }
     self.navigationController.pushViewController(coinDetailViewController, animated: false)
+
+    self.sendSocketTickerMessage()
+    self.sendSocketTransactionMessage()
+    self.sendSocketOrderBookMessage()
+  }
+
+
+  // MARK: Send Socket Message
+
+  private func sendSocketTickerMessage() {
+    WebSocketManager.shared.sendMessage(
+      socketType: .ticker,
+      symbols: WebSocketManager.shared.generateSymbol(with: self.orderCurrency, paymentCurrency: self.paymentCurrency),
+      tickType: "24H"
+    )
   }
   
+  private func sendSocketTransactionMessage() {
+    WebSocketManager.shared.sendMessage(
+      socketType: .transaction,
+      symbols: WebSocketManager.shared.generateSymbol(with: self.orderCurrency, paymentCurrency: self.paymentCurrency),
+      tickType: "24H"
+    )
+  }
+
+  private func sendSocketOrderBookMessage() {
+    WebSocketManager.shared.sendMessage(
+      socketType: .orderbookdepth,
+      symbols: WebSocketManager.shared.generateSymbol(with: self.orderCurrency, paymentCurrency: self.paymentCurrency),
+      tickType: "24H"
+    )
+  }
   
   // MARK: Presentations
   

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailCoordinator.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailCoordinator.swift
@@ -52,7 +52,7 @@ final class CoinDetailCoordinator: Coordinator {
   private func sendSocketTickerMessage() {
     WebSocketManager.shared.sendMessage(
       socketType: .ticker,
-      symbols: WebSocketManager.shared.generateSymbol(with: self.orderCurrency, paymentCurrency: self.paymentCurrency),
+      symbols: WebSocketManager.shared.generateSymbol(with: self.orderCurrency, and: self.paymentCurrency),
       tickType: "24H"
     )
   }
@@ -60,7 +60,7 @@ final class CoinDetailCoordinator: Coordinator {
   private func sendSocketTransactionMessage() {
     WebSocketManager.shared.sendMessage(
       socketType: .transaction,
-      symbols: WebSocketManager.shared.generateSymbol(with: self.orderCurrency, paymentCurrency: self.paymentCurrency),
+      symbols: WebSocketManager.shared.generateSymbol(with: self.orderCurrency, and: self.paymentCurrency),
       tickType: "24H"
     )
   }
@@ -68,7 +68,7 @@ final class CoinDetailCoordinator: Coordinator {
   private func sendSocketOrderBookMessage() {
     WebSocketManager.shared.sendMessage(
       socketType: .orderbookdepth,
-      symbols: WebSocketManager.shared.generateSymbol(with: self.orderCurrency, paymentCurrency: self.paymentCurrency),
+      symbols: WebSocketManager.shared.generateSymbol(with: self.orderCurrency, and: self.paymentCurrency),
       tickType: "24H"
     )
   }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -226,7 +226,6 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
       }
       mergedCellData.append($0)
     }
-    mergedCellData.sortByOrderPrice()
     return mergedCellData
       .filter { $0.orderQuantity != 0 }
       .filter { $0.orderQuantity != nil }
@@ -234,6 +233,7 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
 
   func checked(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
     var cellData = orderBookListViewCellData
+    cellData.sortByOrderPrice()
     if cellData.count > 30 {
       cellData = self.removedUnnecessaryCellData(orderBookListViewCellData: cellData, category: category)
     } else if cellData.count < 30 {

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -190,8 +190,8 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
   func coinPriceData(with response: SocketTickerResponse) -> CoinPriceData {
     return CoinPriceData(
       currentPrice: response.content.closePrice,
-      priceChangedRatio: response.content.chgRate,
-      priceDifference: response.content.chgAmt
+      priceChangedRatio: response.content.changeRate,
+      priceDifference: response.content.changeAmount
     )
   }
 

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -25,7 +25,6 @@ protocol CoinDetailUseCaseLogic {
   func coinPriceData(with response: SocketTickerResponse) -> CoinPriceData
   func transactionSheetViewCellData(with response: SocketTransactionResponse) -> [TransactionSheetViewCellData]
   func mergeOrderBookListViewCellData(preCellData: [OrderBookListViewCellData], postCellData: [OrderBookListViewCellData]) -> [OrderBookListViewCellData]
-  func exceptedEmptyCellData(from cellData: [OrderBookListViewCellData]) -> [OrderBookListViewCellData]
   func checked(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData]
 }
 
@@ -221,10 +220,10 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
         mergedCellData.append($0)
       }
     }
-    return mergedCellData
+    return self.exceptedEmptyCellData(from: mergedCellData)
   }
 
-  func exceptedEmptyCellData(from cellData: [OrderBookListViewCellData]) -> [OrderBookListViewCellData] {
+  private func exceptedEmptyCellData(from cellData: [OrderBookListViewCellData]) -> [OrderBookListViewCellData] {
     return cellData
       .filter { $0.orderQuantity != 0 }
       .filter { $0.orderQuantity != nil }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -25,7 +25,7 @@ protocol CoinDetailUseCaseLogic {
   func coinPriceData(with response: SocketTickerResponse) -> CoinPriceData
   func transactionSheetViewCellData(with response: SocketTransactionResponse) -> [TransactionSheetViewCellData]
   func mergeOrderBookListViewCellData(preCellData: [OrderBookListViewCellData], postCellData: [OrderBookListViewCellData]) -> [OrderBookListViewCellData]
-  func checked(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData]
+  func filledCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData]
 }
 
 final class CoinDetailUseCase: CoinDetailUseCaseLogic {
@@ -216,7 +216,7 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
       .filter { $0.orderQuantity != nil }
   }
 
-  func checked(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
+  func filledCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
     var cellData = orderBookListViewCellData
     cellData.sortByOrderPrice()
     if cellData.count > 30 {

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -25,6 +25,7 @@ protocol CoinDetailUseCaseLogic {
   func coinPriceData(with response: SocketTickerResponse) -> CoinPriceData
   func transactionSheetViewCellData(with response: SocketTransactionResponse) -> [TransactionSheetViewCellData]
   func mergeOrderBookListViewCellData(preCellData: [OrderBookListViewCellData], postCellData: [OrderBookListViewCellData]) -> [OrderBookListViewCellData]
+  func exceptedEmptyCellData(from cellData: [OrderBookListViewCellData]) -> [OrderBookListViewCellData]
   func checked(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData]
 }
 
@@ -221,6 +222,10 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
       }
     }
     return mergedCellData
+  }
+
+  func exceptedEmptyCellData(from cellData: [OrderBookListViewCellData]) -> [OrderBookListViewCellData] {
+    return cellData
       .filter { $0.orderQuantity != 0 }
       .filter { $0.orderQuantity != nil }
   }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -214,14 +214,11 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
   func mergeOrderBookListViewCellData(preCellData: [OrderBookListViewCellData], postCellData: [OrderBookListViewCellData]) -> [OrderBookListViewCellData] {
     var mergedCellData = preCellData
     postCellData.forEach {
-      for index in 0..<mergedCellData.count {
-        guard mergedCellData[safe: index] != nil else { return }
-        if mergedCellData[index].orderPrice == $0.orderPrice {
-          mergedCellData[index] = $0
-          return
-        }
+      if let index = mergedCellData.binarySearchForDescending(item: $0) {
+        mergedCellData[index] = $0
+      } else {
+        mergedCellData.append($0)
       }
-      mergedCellData.append($0)
     }
     return mergedCellData
       .filter { $0.orderQuantity != 0 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -101,11 +101,12 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     var cellData = orderBooks
       .sorted(by: >)
       .map { orderBook -> OrderBookListViewCellData? in
-      guard let orderPrice = Double(orderBook.price) else { return nil }
+      guard let orderPrice = Double(orderBook.price),
+            let quantity = Double(orderBook.quantity) else { return nil }
       return OrderBookListViewCellData(
         orderBookCategory: category,
-        orderPrice: orderBook.price,
-        orderQuantity: orderBook.quantity,
+        orderPrice: orderPrice,
+        orderQuantity: quantity,
         priceChangedRatio: (orderPrice - openingPrice) / orderPrice
       )
     }.compactMap { $0 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -251,6 +251,7 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     } else {
       rangeToRemove = 30..<(30 + exceedCount)
     }
+    guard cellData[safe: rangeToRemove] != nil else { return orderBookListViewCellData }
     cellData.removeSubrange(rangeToRemove)
     return cellData
   }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -233,29 +233,43 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
   }
 
   func checked(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
-    var orderBookListViewCellData = orderBookListViewCellData
-    if orderBookListViewCellData.count > 30 {
-      let exceedCount = orderBookListViewCellData.count - 30
-      if category == .ask {
-        orderBookListViewCellData.removeSubrange(0..<exceedCount)
-      } else {
-        orderBookListViewCellData.removeSubrange(30..<(30 + exceedCount))
-      }
-    } else if orderBookListViewCellData.count < 30 {
-      let emptyCount = 30 - orderBookListViewCellData.count
-      let emptyCellData = Array(
-        repeating: OrderBookListViewCellData(
-          orderBookCategory: category,
-          orderPrice: nil,
-          orderQuantity: nil,
-          priceChangedRatio: nil
-        ), count: emptyCount)
-      if category == .ask {
-        orderBookListViewCellData.insert(contentsOf: emptyCellData, at: .zero)
-      } else {
-        orderBookListViewCellData.append(contentsOf: emptyCellData)
-      }
+    var cellData = orderBookListViewCellData
+    if cellData.count > 30 {
+      cellData = self.removedUnnecessaryCellData(orderBookListViewCellData: cellData, category: category)
+    } else if cellData.count < 30 {
+      cellData = self.filledEmptyCellData(orderBookListViewCellData: cellData, category: category)
     }
-    return orderBookListViewCellData
+    return cellData
+  }
+
+  private func removedUnnecessaryCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
+    var cellData = orderBookListViewCellData
+    let exceedCount = cellData.count - 30
+    var rangeToRemove: Range<Int>
+    if category == .ask {
+      rangeToRemove = 0..<exceedCount
+    } else {
+      rangeToRemove = 30..<(30 + exceedCount)
+    }
+    cellData.removeSubrange(rangeToRemove)
+    return cellData
+  }
+
+  private func filledEmptyCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
+    var cellData = orderBookListViewCellData
+    let emptyCount = 30 - cellData.count
+    let emptyCellData = Array(
+      repeating: OrderBookListViewCellData(
+        orderBookCategory: category,
+        orderPrice: nil,
+        orderQuantity: nil,
+        priceChangedRatio: nil
+      ), count: emptyCount)
+    if category == .ask {
+      cellData.insert(contentsOf: emptyCellData, at: .zero)
+    } else {
+      cellData.append(contentsOf: emptyCellData)
+    }
+    return cellData
   }
 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -198,17 +198,14 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
   func transactionSheetViewCellData(with response: SocketTransactionResponse) -> [TransactionSheetViewCellData] {
     return response.content.list.map { socketTransactionHistory -> TransactionSheetViewCellData? in
       let category = (socketTransactionHistory.upDown == "up") ? OrderBookCategory.ask : OrderBookCategory.bid
-      guard let dateText = socketTransactionHistory.contractDatemessage
-              .split(separator: " ").last?
-              .split(separator: ".").first.map({ String($0) }),
-            let volume = Double(socketTransactionHistory.contractQuantity) else {
+      guard let volume = Double(socketTransactionHistory.contractQuantity) else {
         return nil
       }
 
       return TransactionSheetViewCellData(
         orderBookCategory: category,
         transactionPrice: socketTransactionHistory.contractPrice,
-        dateText: dateText,
+        dateText: socketTransactionHistory.contractDatemessage,
         volume: volume
       )
     }.compactMap { $0 }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -222,7 +222,7 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     if cellData.count > 30 {
       cellData = self.removeUnnecessaryCellData(orderBookListViewCellData: cellData, category: category)
     } else if cellData.count < 30 {
-      cellData = self.fillLackCellData(orderBookListViewCellData: cellData, category: category)
+      cellData = self.addEmptyCellData(orderBookListViewCellData: cellData, category: category)
     }
     return cellData
   }
@@ -246,7 +246,7 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     return cellData
   }
 
-  private func fillLackCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
+  private func addEmptyCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
     let cellData = orderBookListViewCellData
     let emptyCount = 30 - cellData.count
     let emptyCellData = self.emptyCellData(count: emptyCount, category: category)

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailUseCase.swift
@@ -233,14 +233,14 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     var cellData = orderBookListViewCellData
     cellData.sortByOrderPrice()
     if cellData.count > 30 {
-      cellData = self.removedUnnecessaryCellData(orderBookListViewCellData: cellData, category: category)
+      cellData = self.removeUnnecessaryCellData(orderBookListViewCellData: cellData, category: category)
     } else if cellData.count < 30 {
-      cellData = self.filledEmptyCellData(orderBookListViewCellData: cellData, category: category)
+      cellData = self.fillLackCellData(orderBookListViewCellData: cellData, category: category)
     }
     return cellData
   }
 
-  private func removedUnnecessaryCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
+  private func removeUnnecessaryCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
     var cellData = orderBookListViewCellData
     let exceedCount = cellData.count - 30
     var rangeToRemove: Range<Int>
@@ -254,7 +254,7 @@ final class CoinDetailUseCase: CoinDetailUseCaseLogic {
     return cellData
   }
 
-  private func filledEmptyCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
+  private func fillLackCellData(orderBookListViewCellData: [OrderBookListViewCellData], category: OrderBookCategory) -> [OrderBookListViewCellData] {
     var cellData = orderBookListViewCellData
     let emptyCount = 30 - cellData.count
     let emptyCellData = Array(

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -179,10 +179,10 @@ final class CoinDetailViewModel: CoinDetailViewModelLogic {
 
     Observable.merge(transactionSheetViewCellData, socketTransactionSheetViewCellData)
       .observe(on: SerialDispatchQueueScheduler(qos: .default))
-      .scan([TransactionSheetViewCellData]()) { cellData, addedCellData in
-        var addedCellData = addedCellData
-        addedCellData.sortByTimeInterval()
-        return addedCellData + cellData
+      .scan([TransactionSheetViewCellData]()) { cellData, cellDataToUpdate in
+        var cellDataToUpdate = cellDataToUpdate
+        cellDataToUpdate.sortByTimeInterval()
+        return cellDataToUpdate + cellData
       }.bind(to: self.transactionSheetViewModel.transactionSheetViewCellData)
       .disposed(by: self.disposeBag)
   }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -162,8 +162,8 @@ final class CoinDetailViewModel: CoinDetailViewModelLogic {
       guard let preBids = cellData[safe: 30..<60] else { return [] }
       let mergedAsks = useCase.mergeOrderBookListViewCellData(preCellData: preAsks, postCellData: addedCellData.asks)
       let mergedBids = useCase.mergeOrderBookListViewCellData(preCellData: preBids, postCellData: addedCellData.bids)
-      let filledAsksCellData = useCase.checked(orderBookListViewCellData: mergedAsks, category: .ask)
-      let filledBidsCellData = useCase.checked(orderBookListViewCellData: mergedBids, category: .bid)
+      let filledAsksCellData = useCase.filledCellData(orderBookListViewCellData: mergedAsks, category: .ask)
+      let filledBidsCellData = useCase.filledCellData(orderBookListViewCellData: mergedBids, category: .bid)
       return filledAsksCellData + filledBidsCellData
     }.bind(to: self.orderBookListViewModel.orderBookListViewCellData)
       .disposed(by: self.disposeBag)

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -178,9 +178,11 @@ final class CoinDetailViewModel: CoinDetailViewModelLogic {
       .map { useCase.transactionSheetViewCellData(with: $0!) }
 
     Observable.merge(transactionSheetViewCellData, socketTransactionSheetViewCellData)
-      .observe(on: ConcurrentMainScheduler.instance)
-      .scan([TransactionSheetViewCellData]()) { cellData, action in
-        return action + cellData
+      .observe(on: SerialDispatchQueueScheduler(qos: .default))
+      .scan([TransactionSheetViewCellData]()) { cellData, addedCellData in
+        var addedCellData = addedCellData
+        addedCellData.sortByTimeInterval()
+        return addedCellData + cellData
       }.bind(to: self.transactionSheetViewModel.transactionSheetViewCellData)
       .disposed(by: self.disposeBag)
   }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -158,10 +158,10 @@ final class CoinDetailViewModel: CoinDetailViewModelLogic {
       if cellData.count == 0 {
         return addedCellData.asks + addedCellData.bids
       }
-      let preAsks = Array(cellData[0..<30])
-      let preBids = Array(cellData[30..<60])
-      let mergedAsks = useCase.mergeOrderBookListViewCellData(preCellData: preAsks, postCellData: addedCellData.0)
-      let mergedBids = useCase.mergeOrderBookListViewCellData(preCellData: preBids, postCellData: addedCellData.1)
+      guard let preAsks = cellData[safe: 0..<30] else { return [] }
+      guard let preBids = cellData[safe: 30..<60] else { return [] }
+      let mergedAsks = useCase.mergeOrderBookListViewCellData(preCellData: preAsks, postCellData: addedCellData.asks)
+      let mergedBids = useCase.mergeOrderBookListViewCellData(preCellData: preBids, postCellData: addedCellData.bids)
       let filledAsksCellData = useCase.checked(orderBookListViewCellData: mergedAsks, category: .ask)
       let filledBidsCellData = useCase.checked(orderBookListViewCellData: mergedBids, category: .bid)
       return filledAsksCellData + filledBidsCellData

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -162,8 +162,10 @@ final class CoinDetailViewModel: CoinDetailViewModelLogic {
       guard let preBids = cellData[safe: 30..<60] else { return [] }
       let mergedAsks = useCase.mergeOrderBookListViewCellData(preCellData: preAsks, postCellData: addedCellData.asks)
       let mergedBids = useCase.mergeOrderBookListViewCellData(preCellData: preBids, postCellData: addedCellData.bids)
-      let filledAsksCellData = useCase.checked(orderBookListViewCellData: mergedAsks, category: .ask)
-      let filledBidsCellData = useCase.checked(orderBookListViewCellData: mergedBids, category: .bid)
+      let exceptedEmptyAsks = useCase.exceptedEmptyCellData(from: mergedAsks)
+      let exceptedEmptyBids = useCase.exceptedEmptyCellData(from: mergedBids)
+      let filledAsksCellData = useCase.checked(orderBookListViewCellData: exceptedEmptyAsks, category: .ask)
+      let filledBidsCellData = useCase.checked(orderBookListViewCellData: exceptedEmptyBids, category: .bid)
       return filledAsksCellData + filledBidsCellData
     }.bind(to: self.orderBookListViewModel.orderBookListViewCellData)
       .disposed(by: self.disposeBag)

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -124,6 +124,17 @@ final class CoinDetailViewModel: CoinDetailViewModelLogic {
 
     WebSocketManager.shared.socket?.delegate = self
 
+    let socketTickerResponse = self.socketText
+      .map { $0.data(using: .utf8) }
+      .filter { $0 != nil }
+      .map { useCase.socketResponse(with: $0!, type: SocketTickerResponse.self) }
+    
+    socketTickerResponse
+      .filter { $0 != nil }
+      .map { useCase.coinPriceData(with: $0!) }
+      .bind(to: self.currentPriceStatusViewModel.coinPriceData)
+      .disposed(by: self.disposeBag)
+
     let socketTransactionResponse = self.socketText
       .map { $0.data(using: .utf8) }
       .filter { $0 != nil }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailViewModel.swift
@@ -162,10 +162,8 @@ final class CoinDetailViewModel: CoinDetailViewModelLogic {
       guard let preBids = cellData[safe: 30..<60] else { return [] }
       let mergedAsks = useCase.mergeOrderBookListViewCellData(preCellData: preAsks, postCellData: addedCellData.asks)
       let mergedBids = useCase.mergeOrderBookListViewCellData(preCellData: preBids, postCellData: addedCellData.bids)
-      let exceptedEmptyAsks = useCase.exceptedEmptyCellData(from: mergedAsks)
-      let exceptedEmptyBids = useCase.exceptedEmptyCellData(from: mergedBids)
-      let filledAsksCellData = useCase.checked(orderBookListViewCellData: exceptedEmptyAsks, category: .ask)
-      let filledBidsCellData = useCase.checked(orderBookListViewCellData: exceptedEmptyBids, category: .bid)
+      let filledAsksCellData = useCase.checked(orderBookListViewCellData: mergedAsks, category: .ask)
+      let filledBidsCellData = useCase.checked(orderBookListViewCellData: mergedBids, category: .bid)
       return filledAsksCellData + filledBidsCellData
     }.bind(to: self.orderBookListViewModel.orderBookListViewCellData)
       .disposed(by: self.disposeBag)

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusView.swift
@@ -17,7 +17,6 @@ final class CurrentPriceStatusView: UIView {
   private let priceChangedRatioLabel = UILabel()
   private let priceDifferenceLabel = UILabel()
   private let currentPriceLabel = UILabel()
-  
   private let disposeBag = DisposeBag()
   
   

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookCategory.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookCategory.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum OrderBookCategory: String, CaseIterable {
+enum OrderBookCategory: String, CaseIterable, Decodable {
   case bid
   case ask
 

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift
@@ -54,9 +54,9 @@ final class OrderBookListView: UITableView {
         return cell
       }.disposed(by: self.disposeBag)
 
-    viewModel.cellData
-      .drive { orderBookListViewCellData in
-        let centerIndex = orderBookListViewCellData.count / 2
+    viewModel.initialCellData
+      .bind { (asks, bids) in
+        let centerIndex = (asks.count + bids.count) / 2
         self.scrollToRow(at: IndexPath(row: centerIndex, section: .zero),
                          at: .middle, animated: false)
       }.disposed(by: self.disposeBag)

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCellData.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCellData.swift
@@ -11,8 +11,8 @@ import Then
 
 struct OrderBookListViewCellData: Equatable {
   let orderBookCategory: OrderBookCategory
-  let orderPrice: String?
-  let orderQuantity: String?
+  let orderPrice: Double?
+  let orderQuantity: Double?
   let priceChangedRatio: Double?
 }
 

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCellData.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCellData.swift
@@ -9,12 +9,37 @@ import Foundation
 
 import Then
 
-struct OrderBookListViewCellData: Equatable {
+struct OrderBookListViewCellData {
   let orderBookCategory: OrderBookCategory
   let orderPrice: Double?
   let orderQuantity: Double?
   let priceChangedRatio: Double?
 }
+
+
+// MARK: - Equatable
+
+extension OrderBookListViewCellData: Equatable {
+  static func == (lhs: OrderBookListViewCellData, rhs: OrderBookListViewCellData) -> Bool {
+    let lhsPrice = lhs.orderPrice ?? 0
+    let rhsPrice = rhs.orderPrice ?? 0
+    return lhsPrice == rhsPrice
+  }
+}
+
+
+// MARK: - Comparable
+
+extension OrderBookListViewCellData: Comparable {
+  static func < (lhs: OrderBookListViewCellData, rhs: OrderBookListViewCellData) -> Bool {
+    let lhsPrice = lhs.orderPrice ?? 0
+    let rhsPrice = rhs.orderPrice ?? 0
+    return lhsPrice < rhsPrice
+  }
+}
+
+
+// MARK: - Editing Logic
 
 extension OrderBookListViewCellData {
   func priceChangedRatioText() -> NSAttributedString? {

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
@@ -10,22 +10,26 @@ import RxSwift
 import RxCocoa
 
 protocol OrderBookListViewModelLogic {
+  var initialCellData: PublishRelay<([OrderBookListViewCellData], [OrderBookListViewCellData])> { get }
+  var orderBookListViewCellData: PublishRelay<[OrderBookListViewCellData]> { get }
   var cellData: Driver<[OrderBookListViewCellData]> { get }
-  var orderBookListViewCellData: PublishSubject<[OrderBookListViewCellData]> { get }
 }
 
 final class OrderBookListViewModel: OrderBookListViewModelLogic {
 
   // MARK: Properties
 
+  let initialCellData: PublishRelay<([OrderBookListViewCellData], [OrderBookListViewCellData])>
+  let orderBookListViewCellData: PublishRelay<[OrderBookListViewCellData]>
   let cellData: Driver<[OrderBookListViewCellData]>
-  let orderBookListViewCellData: PublishSubject<[OrderBookListViewCellData]>
+  private let disposeBag = DisposeBag()
 
 
   // MARK: Initialzier
 
   init() {
-    self.orderBookListViewCellData = PublishSubject<[OrderBookListViewCellData]>()
+    self.initialCellData = PublishRelay<([OrderBookListViewCellData], [OrderBookListViewCellData])>()
+    self.orderBookListViewCellData = PublishRelay<[OrderBookListViewCellData]>()
     
     self.cellData = self.orderBookListViewCellData
       .asDriver(onErrorJustReturn: [])

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxCocoa
 
 protocol OrderBookListViewModelLogic {
-  var initialCellData: PublishRelay<([OrderBookListViewCellData], [OrderBookListViewCellData])> { get }
+  var initialCellData: PublishRelay<(asks: [OrderBookListViewCellData], bids: [OrderBookListViewCellData])> { get }
   var orderBookListViewCellData: PublishRelay<[OrderBookListViewCellData]> { get }
   var cellData: Driver<[OrderBookListViewCellData]> { get }
 }
@@ -19,7 +19,7 @@ final class OrderBookListViewModel: OrderBookListViewModelLogic {
 
   // MARK: Properties
 
-  let initialCellData: PublishRelay<([OrderBookListViewCellData], [OrderBookListViewCellData])>
+  let initialCellData: PublishRelay<(asks: [OrderBookListViewCellData], bids: [OrderBookListViewCellData])>
   let orderBookListViewCellData: PublishRelay<[OrderBookListViewCellData]>
   let cellData: Driver<[OrderBookListViewCellData]>
   private let disposeBag = DisposeBag()
@@ -28,7 +28,7 @@ final class OrderBookListViewModel: OrderBookListViewModelLogic {
   // MARK: Initialzier
 
   init() {
-    self.initialCellData = PublishRelay<([OrderBookListViewCellData], [OrderBookListViewCellData])>()
+    self.initialCellData = PublishRelay<(asks: [OrderBookListViewCellData], bids: [OrderBookListViewCellData])>()
     self.orderBookListViewCellData = PublishRelay<[OrderBookListViewCellData]>()
     
     self.cellData = self.orderBookListViewCellData

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCell.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCell.swift
@@ -78,7 +78,7 @@ final class TransactionSheetViewCell: UITableViewCell {
   // MARK: Set CellData
 
   func setData(with data: TransactionSheetViewCellData) {
-    self.timeLabel.text = data.dateText
+    self.timeLabel.text = data.timeText
     self.priceLabel.attributedText = data.priceText()
     self.volumeLabel.attributedText = data.volumeText()
   }

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCellData.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCellData.swift
@@ -12,6 +12,22 @@ struct TransactionSheetViewCellData {
   let transactionPrice: String
   let dateText: String
   let volume: Double
+
+  var timeInterval: Double? {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSSSS"
+    let convertedDate = dateFormatter.date(from: self.dateText)
+    return convertedDate?.timeIntervalSince1970
+  }
+
+  var timeText: String? {
+    guard let dateText = self.dateText
+            .split(separator: " ").last?
+            .split(separator: ".").first.map({ String($0) }) else {
+      return nil
+    }
+    return dateText
+  }
 }
 
 extension TransactionSheetViewCellData {

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewModel.swift
@@ -6,10 +6,9 @@
 //
 
 import RxCocoa
-import RxSwift
 
 protocol TransactionSheetViewModelLogic {
-  var transactionSheetViewCellData: PublishSubject<[TransactionSheetViewCellData]> { get }
+  var transactionSheetViewCellData: PublishRelay<[TransactionSheetViewCellData]> { get }
   var cellData: Driver<[TransactionSheetViewCellData]> { get }
 }
 
@@ -17,14 +16,14 @@ final class TransactionSheetViewModel: TransactionSheetViewModelLogic {
 
   // MARK: Properties
 
-  let transactionSheetViewCellData: PublishSubject<[TransactionSheetViewCellData]>
+  let transactionSheetViewCellData: PublishRelay<[TransactionSheetViewCellData]>
   let cellData: Driver<[TransactionSheetViewCellData]>
 
-
+  
   // MARK: Initializer
 
   init() {
-    self.transactionSheetViewCellData = PublishSubject<[TransactionSheetViewCellData]>()
+    self.transactionSheetViewCellData = PublishRelay<[TransactionSheetViewCellData]>()
 
     self.cellData = self.transactionSheetViewCellData
       .asDriver(onErrorJustReturn: [])

--- a/Cryptocurrency/Cryptocurrency/Entity/SocketOrderBookResponse.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/SocketOrderBookResponse.swift
@@ -1,0 +1,41 @@
+//
+//  SocketOrderBookResponse.swift
+//  Cryptocurrency
+//
+//  Created by 이영우 on 2022/02/18.
+//
+
+import Foundation
+
+/**
+ {
+     "type": "orderbookdepth",
+     "content": {
+         "list": [
+             {
+                 "symbol": "BTC_KRW", // Ticker
+                 "orderType": "ask", // 주문타입 – bid / ask
+                 "price": "53365000", // 호가
+                 "quantity": "0", // 잔량
+                 "total": "0" // 건수
+             }
+         ],
+         "datetime": "1644918923346784"
+     }
+ }
+ */
+
+struct SocketOrderBookResponse: Decodable {
+  let type: String
+  let content: SocketOrderBookData
+}
+
+struct SocketOrderBookData: Decodable {
+  let list: [SocketOrderBook]
+  let datetime: String
+}
+
+struct SocketOrderBook: Decodable {
+  let symbol, price, quantity, total: String
+  let orderType: OrderBookCategory
+}

--- a/Cryptocurrency/Cryptocurrency/Entity/SocketTickerResponse.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/SocketTickerResponse.swift
@@ -48,11 +48,21 @@ struct SocketTickerData: Decodable, Equatable {
   let volume: String
   let sellVolume: String
   let buyVolume: String
-  let prevClosePrice: String
-  let chgRate: String
-  let chgAmt: String
+  let previousClosePrice: String
+  let changeRate: String
+  let changeAmount: String
   let volumePower: String
   let symbol: String
+
+  enum CodingKeys: String, CodingKey {
+    case tickType, date, time, openPrice
+    case closePrice, lowPrice, highPrice
+    case value, volume, sellVolume, buyVolume
+    case volumePower, symbol
+    case previousClosePrice = "prevClosePrice"
+    case changeRate = "chgRate"
+    case changeAmount = "chgAmt"
+  }
 
   var ticker: String? {
     guard let ticker = self.symbol.split(separator: "_").first else { return nil }
@@ -65,8 +75,8 @@ struct SocketTickerData: Decodable, Equatable {
       coinName: OrderCurrency.search(with: ticker).koreanName,
       ticker: ticker,
       currentPrice: self.closePrice,
-      priceChangedRatio: self.chgRate,
-      priceDifference: self.chgAmt,
+      priceChangedRatio: self.changeRate,
+      priceDifference: self.changeAmount,
       transactionAmount: value
     )
   }

--- a/Cryptocurrency/Cryptocurrency/Entity/SocketTransactionResponse.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/SocketTransactionResponse.swift
@@ -1,0 +1,51 @@
+//
+//  SocketTransactionResponse.swift
+//  Cryptocurrency
+//
+//  Created by 이영우 on 2022/02/18.
+//
+
+import Foundation
+
+/**
+{
+   "type": "transaction",
+   "content": {
+       "list": [
+           {
+               "buySellGb": "2", // 체결종류(1:매도체결, 매수체결)
+               "contPrice": "51224000", // 체결가격
+               "contQty": "0.106", // 체결수량
+               "contAmt": "5429744.000", // 체결금액
+               "contDtm": "2022-02-14 16:13:40.122852", // 체결 시각
+               "updn": "dn", // 직전 시세와의 비교 up-상승, down-하락
+               "symbol": "BTC_KRW"
+           }
+       ]
+   }
+}
+*/
+
+struct SocketTransactionResponse: Decodable {
+  let type: String
+  let content: SocketTransactionHistoryData
+}
+
+struct SocketTransactionHistoryData: Decodable {
+  let list: [SocketTransactionHistory]
+}
+
+struct SocketTransactionHistory: Decodable {
+  let contractType, contractPrice, contractQuantity: String
+  let contractAmount, contractDatemessage, upDown, symbol: String
+
+  enum CodingKeys: String, CodingKey {
+    case contractType = "buySellGb"
+    case contractPrice = "contPrice"
+    case contractQuantity = "contQty"
+    case contractAmount = "contAmt"
+    case contractDatemessage = "contDtm"
+    case upDown = "updn"
+    case symbol
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/Exchange/Components/CoinList/CoinListViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/Components/CoinList/CoinListViewModel.swift
@@ -86,7 +86,7 @@ extension CoinListViewModel: WebSocketDelegate {
   private func sendSocketTickerMessage() {
     WebSocketManager.shared.sendMessage(
       socketType: SocketType.ticker,
-      symbols: WebSocketManager.shared.generateSymbol(with: .krw),
+      symbols: WebSocketManager.shared.generateAllSymbol(with: .krw),
       tickType: "24H"
     )
   }

--- a/Cryptocurrency/Cryptocurrency/Network/WebSocketManager.swift
+++ b/Cryptocurrency/Cryptocurrency/Network/WebSocketManager.swift
@@ -60,7 +60,7 @@ final class WebSocketManager {
     socket?.write(string: message)
   }
 
-  func generateSymbol(with orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency) -> String {
+  func generateSymbol(with orderCurrency: OrderCurrency, and paymentCurrency: PaymentCurrency) -> String {
     return "\(orderCurrency.rawValue)_\(paymentCurrency.rawValue)"
   }
 

--- a/Cryptocurrency/Cryptocurrency/Network/WebSocketManager.swift
+++ b/Cryptocurrency/Cryptocurrency/Network/WebSocketManager.swift
@@ -60,7 +60,11 @@ final class WebSocketManager {
     socket?.write(string: message)
   }
 
-  func generateSymbol(with paymentCurreny: PaymentCurrency) -> String {
+  func generateSymbol(with orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency) -> String {
+    return "\(orderCurrency.rawValue)_\(paymentCurrency.rawValue)"
+  }
+
+  func generateAllSymbol(with paymentCurreny: PaymentCurrency) -> String {
     return OrderCurrency.allCases
       .filter { $0 != .all }
       .map { return $0.rawValue + "_\(paymentCurreny.rawValue)" }

--- a/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
+++ b/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
@@ -12,7 +12,7 @@ extension Array {
     return self.indices ~= index ? self[index] : nil
   }
 
-  mutating func sort() where Element == OrderBookListViewCellData {
+  mutating func sortByOrderPrice() where Element == OrderBookListViewCellData {
     self.sort { lhs, rhs in
       let lhsPrice = lhs.orderPrice ?? 0.0
       let rhsPrice = rhs.orderPrice ?? 0.0

--- a/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
+++ b/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
@@ -12,6 +12,13 @@ extension Array {
     return self.indices ~= index ? self[index] : nil
   }
 
+  subscript(safe range: Range<Int>) -> [Element]? {
+    let lower = range.lowerBound
+    let upper = range.upperBound - 1
+    let isContained = self.indices ~= (upper) && self.indices ~= (lower)
+    return isContained ? Array(self[range]) : nil
+  }
+
   mutating func sortByOrderPrice() where Element == OrderBookListViewCellData {
     self.sort { lhs, rhs in
       let lhsPrice = lhs.orderPrice ?? 0.0

--- a/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
+++ b/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
@@ -11,4 +11,12 @@ extension Array {
   subscript(safe index: Int) -> Element? {
     return self.indices ~= index ? self[index] : nil
   }
+
+  mutating func sort() where Element == OrderBookListViewCellData {
+    self.sort { lhs, rhs in
+      let lhsPrice = lhs.orderPrice ?? 0.0
+      let rhsPrice = rhs.orderPrice ?? 0.0
+      return lhsPrice > rhsPrice
+    }
+  }
 }

--- a/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
+++ b/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
@@ -34,4 +34,23 @@ extension Array {
       return lhsTimeInterval > rhsTimeInterval
     }
   }
+  
+  func binarySearchForDescending(item: Element) -> Int? where Element: Comparable {
+    var low = 0
+    var high = self.count - 1
+
+    while low <= high {
+      let mid = (low + high) / 2
+      let guess = self[mid]
+      if guess == item {
+        return mid
+      } else if guess < item {
+        high = mid - 1
+      } else {
+        low = mid + 1
+      }
+    }
+
+    return nil
+  }
 }

--- a/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
+++ b/Cryptocurrency/Cryptocurrency/Resources/Extensions/Array + Ext.swift
@@ -26,4 +26,12 @@ extension Array {
       return lhsPrice > rhsPrice
     }
   }
+
+  mutating func sortByTimeInterval() where Element == TransactionSheetViewCellData {
+    self.sort { lhs, rhs in
+      let lhsTimeInterval = lhs.timeInterval ?? 0.0
+      let rhsTimeInterval = rhs.timeInterval ?? 0.0
+      return lhsTimeInterval > rhsTimeInterval
+    }
+  }
 }

--- a/Cryptocurrency/Cryptocurrency/Resources/Extensions/Double + Ext.swift
+++ b/Cryptocurrency/Cryptocurrency/Resources/Extensions/Double + Ext.swift
@@ -17,4 +17,16 @@ extension Double {
       return "-"
     }
   }
+
+  func convertToDecimalText() -> String? {
+    let numberFormatter = NumberFormatter()
+    numberFormatter.maximumFractionDigits = 4
+    numberFormatter.numberStyle = .decimal
+    
+    guard let convertedText = numberFormatter.string(for: self) else {
+      return nil
+    }
+    
+    return convertedText
+  }
 }

--- a/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
+++ b/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
@@ -228,7 +228,7 @@ final class CoinDetailUseCaseTests: XCTestCase {
     let data = socketText.data(using: .utf8)!
 
     //when
-    let socketTickerResponse = self.sut.socketResponse(with: data, type: SocketTickerResponse.self)
+    let socketTickerResponse = self.sut.decodedSocketResponse(as: SocketTickerResponse.self, with: data)
 
     //then
     expect(socketTickerResponse).toNot(beNil())
@@ -256,7 +256,7 @@ final class CoinDetailUseCaseTests: XCTestCase {
     let data = socketText.data(using: .utf8)!
 
     //when
-    let socketOrderBookResponse = self.sut.socketResponse(with: data, type: SocketOrderBookResponse.self)
+    let socketOrderBookResponse = self.sut.decodedSocketResponse(as: SocketOrderBookResponse.self, with: data)
 
     //then
     expect(socketOrderBookResponse).toNot(beNil())
@@ -285,7 +285,7 @@ final class CoinDetailUseCaseTests: XCTestCase {
     let data = socketText.data(using: .utf8)!
 
     //when
-    let socketTransactionResponse = self.sut.socketResponse(with: data, type: SocketTransactionResponse.self)
+    let socketTransactionResponse = self.sut.decodedSocketResponse(as: SocketTransactionResponse.self, with: data)
 
     //then
     expect(socketTransactionResponse).toNot(beNil())
@@ -408,10 +408,10 @@ final class CoinDetailUseCaseTests: XCTestCase {
         orderQuantity: 1, priceChangedRatio: 0
       )
     ]
-    
+
     //when
-    let cellData = self.sut.mergeOrderBookListViewCellData(pre: preOrderBookListViewCellData,
-                                                           post: postOrderBookListViewCellData)
+    let cellData = self.sut.mergeOrderBookListViewCellData(preCellData: preOrderBookListViewCellData,
+                                                           postCellData: postOrderBookListViewCellData)
 
     //then
     expect(cellData).to(equal(expectedCellData))

--- a/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
+++ b/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
@@ -444,7 +444,7 @@ final class CoinDetailUseCaseTests: XCTestCase {
       TransactionSheetViewCellData(
         orderBookCategory: .bid,
         transactionPrice: "51224000",
-        dateText: "16:13:40",
+        dateText: "2022-02-14 16:13:40.122852",
         volume: 0.106
       )
     ]
@@ -533,7 +533,7 @@ final class CoinDetailUseCaseTests: XCTestCase {
     ]
 
     //when
-    let cellData = self.sut.checked(orderBookListViewCellData: orderBookListViewCellData,
+    let cellData = self.sut.filledCellData(orderBookListViewCellData: orderBookListViewCellData,
                                     category: .ask)
 
     //then
@@ -555,7 +555,7 @@ final class CoinDetailUseCaseTests: XCTestCase {
     let expectedCount = 30
 
     //when
-    let cellData = self.sut.checked(orderBookListViewCellData: orderBookListViewCellData,
+    let cellData = self.sut.filledCellData(orderBookListViewCellData: orderBookListViewCellData,
                                     category: .ask)
 
     //then

--- a/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
+++ b/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
@@ -226,12 +226,36 @@ final class CoinDetailUseCaseTests: XCTestCase {
     }
     """
     let data = socketText.data(using: .utf8)!
+    let expectedResponse = SocketTickerResponse(
+      type: "ticker",
+      content: SocketTickerData(
+        tickType: "24H",
+        date: "20200129",
+        time: "121844",
+        openPrice: "2302",
+        closePrice: "2317",
+        lowPrice: "2272",
+        highPrice: "2344",
+        value: "2831915078.07065789",
+        volume: "1222314.51355788",
+        sellVolume: "760129.34079004",
+        buyVolume: "462185.17276784",
+        previousClosePrice: "2326",
+        changeRate: "0.65",
+        changeAmount: "15",
+        volumePower: "60.80",
+        symbol: "BTC_KRW"
+      )
+    )
 
     //when
     let socketTickerResponse = self.sut.decodedSocketResponse(as: SocketTickerResponse.self, with: data)
 
     //then
     expect(socketTickerResponse).toNot(beNil())
+    expect(socketTickerResponse!.content.closePrice).to(equal(expectedResponse.content.closePrice))
+    expect(socketTickerResponse!.content.openPrice).to(equal(expectedResponse.content.openPrice))
+    expect(socketTickerResponse!.content.changeRate).to(equal(expectedResponse.content.changeRate))
   }
 
   func text_SocketOrderBookResponse에_해당하는_data가_들어올_경우_Decoding성공_후_entity를_반환() {
@@ -254,12 +278,31 @@ final class CoinDetailUseCaseTests: XCTestCase {
     }
     """
     let data = socketText.data(using: .utf8)!
+    let expectedResponse = SocketOrderBookResponse(
+      type: "orderbookdepth",
+      content: SocketOrderBookData(
+        list: [
+          SocketOrderBook(
+            symbol: "BTC_KRW",
+            price: "53365000",
+            quantity: "0",
+            total: "0",
+            orderType: .ask
+          )
+        ],
+        datetime: "1644918923346784"
+      )
+    )
 
     //when
     let socketOrderBookResponse = self.sut.decodedSocketResponse(as: SocketOrderBookResponse.self, with: data)
 
     //then
     expect(socketOrderBookResponse).toNot(beNil())
+    expect(socketOrderBookResponse!.content.list.first).toNot(beNil())
+    expect(socketOrderBookResponse!.content.list.first!.symbol).to(equal(expectedResponse.content.list.first!.symbol))
+    expect(socketOrderBookResponse!.content.list.first!.price).to(equal(expectedResponse.content.list.first!.price))
+    expect(socketOrderBookResponse!.content.list.first!.quantity).to(equal(expectedResponse.content.list.first!.quantity))
   }
 
   func test_SocketTransactionResponse에_해당하는_data가_들어올_경우_Decoding성공_후_entity를_반환() {
@@ -283,12 +326,32 @@ final class CoinDetailUseCaseTests: XCTestCase {
     }
     """
     let data = socketText.data(using: .utf8)!
+    let expectedResponse = SocketTransactionResponse(
+      type: "transaction",
+      content: SocketTransactionHistoryData(
+        list: [
+          SocketTransactionHistory(
+            contractType: "2",
+            contractPrice: "51224000",
+            contractQuantity: "0.106",
+            contractAmount: "5429744.000",
+            contractDatemessage: "2022-02-14 16:13:40.122852",
+            upDown: "dn",
+            symbol: "BTC_KRW"
+          )
+        ]
+      )
+    )
 
     //when
     let socketTransactionResponse = self.sut.decodedSocketResponse(as: SocketTransactionResponse.self, with: data)
 
     //then
     expect(socketTransactionResponse).toNot(beNil())
+    expect(socketTransactionResponse!.content.list.first).toNot(beNil())
+    expect(socketTransactionResponse!.content.list.first!.contractType).to(equal(expectedResponse.content.list.first!.contractType))
+    expect(socketTransactionResponse!.content.list.first!.contractPrice).to(equal(expectedResponse.content.list.first!.contractPrice))
+    expect(socketTransactionResponse!.content.list.first!.contractAmount).to(equal(expectedResponse.content.list.first!.contractAmount))
   }
 
   func test_SocketTickerResponse에_해당되는_tickerData를_반환() {
@@ -337,6 +400,14 @@ final class CoinDetailUseCaseTests: XCTestCase {
         datetime: "1644918923346784"
       )
     )
+    let expectedCellData = [
+      OrderBookListViewCellData(
+        orderBookCategory: .ask,
+        orderPrice: 53365000,
+        orderQuantity: 11.0,
+        priceChangedRatio: 0
+      )
+    ]
 
     //when
     let orderBookListViewCellData = self.sut.orderBookListViewCellData(with: socketOrderBookResponse,
@@ -345,6 +416,10 @@ final class CoinDetailUseCaseTests: XCTestCase {
 
     //then
     expect(orderBookListViewCellData).toNot(beEmpty())
+    expect(orderBookListViewCellData.first!.orderBookCategory).to(equal(expectedCellData.first!.orderBookCategory))
+    expect(orderBookListViewCellData.first!.orderPrice).to(equal(expectedCellData.first!.orderPrice))
+    expect(orderBookListViewCellData.first!.orderQuantity).to(equal(expectedCellData.first!.orderQuantity))
+    expect(orderBookListViewCellData.first!.priceChangedRatio).to(equal(expectedCellData.first!.priceChangedRatio))
   }
 
   func test_SocketTransactionResponse에_해당되는_배열을_반환() {
@@ -354,18 +429,35 @@ final class CoinDetailUseCaseTests: XCTestCase {
       content: SocketTransactionHistoryData(
         list: [
           SocketTransactionHistory(
-            contractType: "2", contractPrice: "51224000",
-            contractQuantity: "0.106", contractAmount: "5429744.0",
+            contractType: "2",
+            contractPrice: "51224000",
+            contractQuantity: "0.106",
+            contractAmount: "5429744.0",
             contractDatemessage: "2022-02-14 16:13:40.122852",
-            upDown: "dn", symbol: "BTC_KRW")]
+            upDown: "dn",
+            symbol: "BTC_KRW"
+          )
+        ]
       )
     )
+    let expectedCellData = [
+      TransactionSheetViewCellData(
+        orderBookCategory: .bid,
+        transactionPrice: "51224000",
+        dateText: "16:13:40",
+        volume: 0.106
+      )
+    ]
 
     //when
     let transactionSheetViewCellData = self.sut.transactionSheetViewCellData(with: socketTransactionResponse)
 
     //then
     expect(transactionSheetViewCellData).toNot(beEmpty())
+    expect(transactionSheetViewCellData.first!.orderBookCategory).to(equal(expectedCellData.first!.orderBookCategory))
+    expect(transactionSheetViewCellData.first!.transactionPrice).to(equal(expectedCellData.first!.transactionPrice))
+    expect(transactionSheetViewCellData.first!.dateText).to(equal(expectedCellData.first!.dateText))
+    expect(transactionSheetViewCellData.first!.volume).to(equal(expectedCellData.first!.volume))
   }
 
   func test_OrderBookListViewCellData를_합칠경우_Quantity가_0혹은_nil제외한_배열_반환() {
@@ -396,15 +488,15 @@ final class CoinDetailUseCaseTests: XCTestCase {
     ]
     let expectedCellData = [
       OrderBookListViewCellData(
-        orderBookCategory: .ask, orderPrice: 333000,
-        orderQuantity: 1, priceChangedRatio: 0
-      ),
-      OrderBookListViewCellData(
         orderBookCategory: .ask, orderPrice: 222000,
         orderQuantity: 1, priceChangedRatio: 0
       ),
       OrderBookListViewCellData(
         orderBookCategory: .ask, orderPrice: 111000,
+        orderQuantity: 1, priceChangedRatio: 0
+      ),
+      OrderBookListViewCellData(
+        orderBookCategory: .ask, orderPrice: 333000,
         orderQuantity: 1, priceChangedRatio: 0
       )
     ]

--- a/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
+++ b/Cryptocurrency/CryptocurrencyTests/CoinDetail/CoinDetailUseCaseTests.swift
@@ -300,8 +300,8 @@ final class CoinDetailUseCaseTests: XCTestCase {
         openPrice: "2302", closePrice: "2317", lowPrice: "2272",
         highPrice: "2344", value: "2831915078.07065789",
         volume: "1222314.51355788", sellVolume: "760129.34079004",
-        buyVolume: "462185.17276784", prevClosePrice: "2326",
-        chgRate: "0.65", chgAmt: "15", volumePower: "60.80",
+        buyVolume: "462185.17276784", previousClosePrice: "2326",
+        changeRate: "0.65", changeAmount: "15", volumePower: "60.80",
         symbol: "BTC_KRW"
       )
     )

--- a/Cryptocurrency/CryptocurrencyTests/Exchange/Components/CoinListView/CoinListViewModelTests.swift
+++ b/Cryptocurrency/CryptocurrencyTests/Exchange/Components/CoinListView/CoinListViewModelTests.swift
@@ -49,9 +49,9 @@ class CoinListViewModelTests: XCTestCase {
         volume: "31667.982402273023022265",
         sellVolume: "13969.678445247542400307",
         buyVolume: "17698.303957025480621958",
-        prevClosePrice: "3460000",
-        chgRate: "5.89",
-        chgAmt: "205000",
+        previousClosePrice: "3460000",
+        changeRate: "5.89",
+        changeAmount: "205000",
         volumePower: "126.69",
         symbol: "ETH_KRW"
       )


### PR DESCRIPTION
## 배경
- #65 
- 소켓 연결 후, 현재가 정보, 호가창 정보, 시세창 정보 등을 실시간 업데이트 해요

## 수정 내역
- 소켓 연결 후 들어오는 데이터를 파싱해줄 Entity 타입을 생성 및 구현했어요
- Entity 타입을 가공할 메서드들을 UseCase에서 구현했어요
- CoinDetailViewModel 에서 가공된 Data들을 각 UI 컴포넌트들의 ViewModel 로 연결해요

## 테스트 방법
- 유닛 테스트
UseCase에서 생성해준 메서드들에 대한 테스트 케이스를 작성하였어요

- 구동 테스트

![Simulator Screen Recording - iPhone 11 - 2022-02-18 at 14 21 14](https://user-images.githubusercontent.com/64566207/154622638-786a3108-372d-4b78-a4f8-e21860ab4bc5.gif)
