### PR TITLE
[#42] 거래소 화면에 코인 관심 목록을 구현하고 가상화폐 상세 화면에서 관심 추가 및 해제 기능을 구현해요

### DIFF
--- a/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
+++ b/Cryptocurrency/Cryptocurrency.xcodeproj/project.pbxproj
@@ -60,6 +60,14 @@
 		6E81022DFE3C112F391F11E3 /* Pods_Cryptocurrency.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37E3CD0B0B4C1BB8739D6FF2 /* Pods_Cryptocurrency.framework */; };
 		8969AA1FAB5F2398384F2288 /* Pods_Cryptocurrency_CryptocurrencyUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 388D7592CDA05156AF39D1F0 /* Pods_Cryptocurrency_CryptocurrencyUITests.framework */; };
 		99F404AFB7C243C4F6D085D5 /* Pods_CryptocurrencyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D7AF4C66C58E53CF5F605F6 /* Pods_CryptocurrencyTests.framework */; };
+		B42D1FCD27BCC4280031EF99 /* FavoriteGridViewCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42D1FCC27BCC4280031EF99 /* FavoriteGridViewCellData.swift */; };
+		B42D1FCF27BD53250031EF99 /* FavoriteGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42D1FCE27BD53250031EF99 /* FavoriteGridView.swift */; };
+		B42D1FD127BD537C0031EF99 /* FavoriteGridViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42D1FD027BD537C0031EF99 /* FavoriteGridViewCell.swift */; };
+		B42D1FD327BD76100031EF99 /* FavoriteGridViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42D1FD227BD76100031EF99 /* FavoriteGridViewModel.swift */; };
+		B47C0C5627BF65F500A72FFC /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47C0C5527BF65F500A72FFC /* PersistenceManager.swift */; };
+		B47C0C5827C2469D00A72FFC /* UserDefaultsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47C0C5727C2469D00A72FFC /* UserDefaultsError.swift */; };
+		B47C0C5A27C24D1A00A72FFC /* CoinDetailFavoriteButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47C0C5927C24D1A00A72FFC /* CoinDetailFavoriteButtonState.swift */; };
+		B47C0C5C27C251E400A72FFC /* CoinItemCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47C0C5B27C251E400A72FFC /* CoinItemCurrency.swift */; };
 		B49FDAF827AA6C8D001A11E9 /* CharacterSet + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49FDAF727AA6C8D001A11E9 /* CharacterSet + Ext.swift */; };
 		B49FDAFB27AAAFF5001A11E9 /* LetterSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49FDAFA27AAAFF5001A11E9 /* LetterSeparator.swift */; };
 		B4A8E115279AD60B00A2BFCD /* UIColor + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */; };
@@ -182,6 +190,14 @@
 		6AB2300BEDEC951E3984AC29 /* Pods-Cryptocurrency.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Cryptocurrency.debug.xcconfig"; path = "Target Support Files/Pods-Cryptocurrency/Pods-Cryptocurrency.debug.xcconfig"; sourceTree = "<group>"; };
 		8D7AF4C66C58E53CF5F605F6 /* Pods_CryptocurrencyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CryptocurrencyTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB671D49752CBE7CAF3A329E /* Pods-Cryptocurrency-CryptocurrencyUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Cryptocurrency-CryptocurrencyUITests.release.xcconfig"; path = "Target Support Files/Pods-Cryptocurrency-CryptocurrencyUITests/Pods-Cryptocurrency-CryptocurrencyUITests.release.xcconfig"; sourceTree = "<group>"; };
+		B42D1FCC27BCC4280031EF99 /* FavoriteGridViewCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteGridViewCellData.swift; sourceTree = "<group>"; };
+		B42D1FCE27BD53250031EF99 /* FavoriteGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteGridView.swift; sourceTree = "<group>"; };
+		B42D1FD027BD537C0031EF99 /* FavoriteGridViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteGridViewCell.swift; sourceTree = "<group>"; };
+		B42D1FD227BD76100031EF99 /* FavoriteGridViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteGridViewModel.swift; sourceTree = "<group>"; };
+		B47C0C5527BF65F500A72FFC /* PersistenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceManager.swift; sourceTree = "<group>"; };
+		B47C0C5727C2469D00A72FFC /* UserDefaultsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsError.swift; sourceTree = "<group>"; };
+		B47C0C5927C24D1A00A72FFC /* CoinDetailFavoriteButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailFavoriteButtonState.swift; sourceTree = "<group>"; };
+		B47C0C5B27C251E400A72FFC /* CoinItemCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinItemCurrency.swift; sourceTree = "<group>"; };
 		B49FDAF727AA6C8D001A11E9 /* CharacterSet + Ext.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "CharacterSet + Ext.swift"; sourceTree = "<group>"; tabWidth = 2; };
 		B49FDAFA27AAAFF5001A11E9 /* LetterSeparator.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = LetterSeparator.swift; sourceTree = "<group>"; tabWidth = 2; };
 		B4A8E114279AD60B00A2BFCD /* UIColor + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor + Ext.swift"; sourceTree = "<group>"; };
@@ -271,6 +287,7 @@
 		48256CD42799715A008F2AD1 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				B42D1FC927BCBD060031EF99 /* FavoriteGridView */,
 				48256CD627997179008F2AD1 /* ExchangeSearchBar */,
 				B4A8E116279BF11100A2BFCD /* ExchangeSegmentedControl */,
 				48256CD52799716C008F2AD1 /* CoinList */,
@@ -320,6 +337,7 @@
 				48A49ECE27A9772000DF5124 /* SocketTickerResponse.swift */,
 				C333E9DD27B2C40F004F92CE /* OrderBookResponse.swift */,
 				C333E9DB27B2C3F2004F92CE /* TransactionHistoryResponse.swift */,
+				B47C0C5B27C251E400A72FFC /* CoinItemCurrency.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -441,6 +459,7 @@
 				C3D0EF9B27A8AC1F00A5E4BE /* CoinDetailViewModel.swift */,
 				C329A88927AED08400193A4D /* CoinDetailUseCase.swift */,
 				C333E9D127B294DD004F92CE /* CoinDetailCategory.swift */,
+				B47C0C5927C24D1A00A72FFC /* CoinDetailFavoriteButtonState.swift */,
 				4885376427A40E4000BE00FD /* CoinDetailCoordinator.swift */,
 			);
 			path = CoinDetail;
@@ -529,6 +548,7 @@
 				4885376127A40E1C00BE00FD /* CoinDetail */,
 				4881F42527979DDF00472C90 /* Exchange */,
 				48256CE52799730A008F2AD1 /* Network */,
+				B47C0C5427BF65C400A72FFC /* UserDefaults */,
 				48256CE827997415008F2AD1 /* Entity */,
 				4881F42327979D8B00472C90 /* Resources */,
 				4881F4322797A25100472C90 /* TBD */,
@@ -564,6 +584,26 @@
 				8D7AF4C66C58E53CF5F605F6 /* Pods_CryptocurrencyTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B42D1FC927BCBD060031EF99 /* FavoriteGridView */ = {
+			isa = PBXGroup;
+			children = (
+				B42D1FCE27BD53250031EF99 /* FavoriteGridView.swift */,
+				B42D1FD227BD76100031EF99 /* FavoriteGridViewModel.swift */,
+				B42D1FD027BD537C0031EF99 /* FavoriteGridViewCell.swift */,
+				B42D1FCC27BCC4280031EF99 /* FavoriteGridViewCellData.swift */,
+			);
+			path = FavoriteGridView;
+			sourceTree = "<group>";
+		};
+		B47C0C5427BF65C400A72FFC /* UserDefaults */ = {
+			isa = PBXGroup;
+			children = (
+				B47C0C5727C2469D00A72FFC /* UserDefaultsError.swift */,
+				B47C0C5527BF65F500A72FFC /* PersistenceManager.swift */,
+			);
+			path = UserDefaults;
 			sourceTree = "<group>";
 		};
 		B49FDAF927AAAFDE001A11E9 /* LetterSeparator */ = {
@@ -972,6 +1012,7 @@
 				4885375E27A3D91D00BE00FD /* TransactionCoordinator.swift in Sources */,
 				4885376027A3D92800BE00FD /* MoreOptionCoordinator.swift in Sources */,
 				C329A8AA27B15BE900193A4D /* CoinDetailSegmentedCategoryView.swift in Sources */,
+				B47C0C5A27C24D1A00A72FFC /* CoinDetailFavoriteButtonState.swift in Sources */,
 				C333E9D027B292B5004F92CE /* CoinDetailSegmentedCategoryViewModel.swift in Sources */,
 				C3781FC827B7EF90002586FA /* TransactionSheetView.swift in Sources */,
 				48256CE4279972AA008F2AD1 /* CoinListViewCell.swift in Sources */,
@@ -982,6 +1023,7 @@
 				C3D0EF9327A8A30500A5E4BE /* TimeUnitBottomSheetViewModel.swift in Sources */,
 				48C7E8F3279E79E5003C4B25 /* CoinListViewCellData.swift in Sources */,
 				C333E9CC27B25D1A004F92CE /* CurrentPriceStatusViewModel.swift in Sources */,
+				B42D1FD127BD537C0031EF99 /* FavoriteGridViewCell.swift in Sources */,
 				C3D0EF7127A777CA00A5E4BE /* BottomSheet.swift in Sources */,
 				4885376527A40E4000BE00FD /* CoinDetailCoordinator.swift in Sources */,
 				48256CDE2799727D008F2AD1 /* ExchangeSearchBarViewModel.swift in Sources */,
@@ -997,6 +1039,7 @@
 				4885375C27A3D90E00BE00FD /* CurrentAssetCoordinator.swift in Sources */,
 				48256CD82799722E008F2AD1 /* ExchangeViewModel.swift in Sources */,
 				C329A80A27AB8DA600193A4D /* CandleStickResponse.swift in Sources */,
+				B47C0C5827C2469D00A72FFC /* UserDefaultsError.swift in Sources */,
 				48A49ECF27A9772000DF5124 /* SocketTickerResponse.swift in Sources */,
 				48256CE02799728C008F2AD1 /* CoinListView.swift in Sources */,
 				489FB624279C43F10078AEE1 /* APINetworkError.swift in Sources */,
@@ -1020,16 +1063,21 @@
 				48D6C3D527B69A71000CB5AB /* CoinListSortCriterion.swift in Sources */,
 				C329A89927B0C59500193A4D /* PaddingLabel.swift in Sources */,
 				C3781FC627B7EF28002586FA /* TransactionSheetViewCell.swift in Sources */,
+				B42D1FD327BD76100031EF99 /* FavoriteGridViewModel.swift in Sources */,
 				C333E9CA27B259F1004F92CE /* CurrentPriceStatusView.swift in Sources */,
+				B47C0C5C27C251E400A72FFC /* CoinItemCurrency.swift in Sources */,
 				4885375627A3CFF800BE00FD /* AppCoordinator.swift in Sources */,
 				4885376327A40E3600BE00FD /* CoinDetailViewController.swift in Sources */,
 				4881F4302797A22200472C90 /* CurrentAssetViewController.swift in Sources */,
 				48FDCFFE279541E2002F0050 /* SceneDelegate.swift in Sources */,
+				B42D1FCD27BCC4280031EF99 /* FavoriteGridViewCellData.swift in Sources */,
 				4885375827A3D1F500BE00FD /* ExchangeCoordinator.swift in Sources */,
+				B42D1FCF27BD53250031EF99 /* FavoriteGridView.swift in Sources */,
 				C329A88A27AED08400193A4D /* CoinDetailUseCase.swift in Sources */,
 				C3D9461B27A9991000EDE8FF /* TimeUnitBottomSheetCoordinator.swift in Sources */,
 				48256CDC27997267008F2AD1 /* ExchangeSearchBar.swift in Sources */,
 				C329A87D27AECD9900193A4D /* CoinChartView.swift in Sources */,
+				B47C0C5627BF65F500A72FFC /* PersistenceManager.swift in Sources */,
 				C329A88827AECFD600193A4D /* CryptoCurrencyDataType.swift in Sources */,
 				488F9E7C279BA68F0021A545 /* AllTickerResponse.swift in Sources */,
 				48311FE027AF9D8B002F1E87 /* ExchangeSegmentedCategoryView.swift in Sources */,

--- a/Cryptocurrency/Cryptocurrency.xcworkspace/contents.xcworkspacedata
+++ b/Cryptocurrency/Cryptocurrency.xcworkspace/contents.xcworkspacedata
@@ -4,6 +4,382 @@
    <FileRef
       location = "group:Cryptocurrency.xcodeproj">
    </FileRef>
+   <Group
+      location = "group:Cryptocurrency"
+      name = "Cryptocurrency">
+      <Group
+         location = "group:Cryptocurrency/UserDefaults"
+         name = "UserDefaults">
+         <FileRef
+            location = "group:Cryptocurrency/UserDefaults/PersistenceManager.swift">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:Cryptocurrency/CoinDetail"
+         name = "CoinDetail">
+         <Group
+            location = "group:Cryptocurrency/CoinDetail/Components"
+            name = "Components">
+            <Group
+               location = "group:Cryptocurrency/CoinDetail/Components/TransactionSheetView"
+               name = "TransactionSheetView">
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewModel.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCell.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/TransactionSheetView/TransactionSheetViewCellData.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView"
+               name = "CurrentPriceStatusView">
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CurrentPriceStatusViewModel.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/CurrentPriceStatusView/CoinPriceData.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Cryptocurrency/CoinDetail/Components/CoinDetailSegmentedCategoryView"
+               name = "CoinDetailSegmentedCategoryView">
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/CoinDetailSegmentedCategoryView/CoinDetailSegmentedCategoryView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/CoinDetailSegmentedCategoryView/CoinDetailSegmentedCategoryViewModel.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Cryptocurrency/CoinDetail/Components/CoinChartView"
+               name = "CoinChartView">
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/CoinChartView/CoinChartView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/CoinChartView/CoinChartViewModel.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/CoinChartView/ChartData.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Cryptocurrency/CoinDetail/Components/TimeIntervalBottomSheet"
+               name = "TimeIntervalBottomSheet">
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/TimeIntervalBottomSheet/TimeUnitBottomSheet.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/TimeIntervalBottomSheet/TimeUnitBottomSheetViewModel.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/TimeIntervalBottomSheet/TimeUnit.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/TimeIntervalBottomSheet/TimeUnitBottomSheetCoordinator.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Cryptocurrency/CoinDetail/Components/OrderBookListView"
+               name = "OrderBookListView">
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewModel.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCell.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookListViewCellData.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/CoinDetail/Components/OrderBookListView/OrderBookCategory.swift">
+               </FileRef>
+            </Group>
+         </Group>
+         <FileRef
+            location = "group:Cryptocurrency/CoinDetail/CoinDetailViewController.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/CoinDetail/CoinDetailViewModel.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/CoinDetail/CoinDetailUseCase.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/CoinDetail/CoinDetailCategory.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/CoinDetail/CoinDetailCoordinator.swift">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:Cryptocurrency/Exchange"
+         name = "Exchange">
+         <Group
+            location = "group:Cryptocurrency/Exchange/Components"
+            name = "Components">
+            <Group
+               location = "group:Cryptocurrency/Exchange/Components/FavoriteGridView"
+               name = "FavoriteGridView">
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridViewModel.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridViewCell.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridViewCellData.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Cryptocurrency/Exchange/Components/ExchangeSearchBar"
+               name = "ExchangeSearchBar">
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/ExchangeSearchBar/ExchangeSearchBar.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/ExchangeSearchBar/ExchangeSearchBarViewModel.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Cryptocurrency/Exchange/Components/ExchangeSegmentedControl"
+               name = "ExchangeSegmentedControl">
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/ExchangeSegmentedControl/ExchangeSegmentedCategoryView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/ExchangeSegmentedControl/ExchangeSegmentedCategoryViewModel.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Cryptocurrency/Exchange/Components/CoinList"
+               name = "CoinList">
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/CoinList/CoinListView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/CoinList/CoinListViewModel.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/CoinList/CoinListViewCell.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/CoinList/CoinListViewCellData.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Cryptocurrency/Exchange/Components/CoinListSort"
+               name = "CoinListSort">
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/CoinListSort/CoinListSortView.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/CoinListSort/CoinListSortViewModel.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Cryptocurrency/Exchange/Components/CoinListSort/CoinListSortCriterion.swift">
+               </FileRef>
+            </Group>
+         </Group>
+         <FileRef
+            location = "group:Cryptocurrency/Exchange/ExchangeViewController.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Exchange/ExchangeViewModel.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Exchange/ExchangeUseCase.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Exchange/ExchangeCoordinator.swift">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:Cryptocurrency/Network"
+         name = "Network">
+         <FileRef
+            location = "group:Cryptocurrency/Network/APINetworkError.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Network/NetworkManager.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Network/NetworkRequestRouter.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Network/WebSocketManager.swift">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:Cryptocurrency/Entity"
+         name = "Entity">
+         <FileRef
+            location = "group:Cryptocurrency/Entity/AllTickerResponse.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Entity/Currency.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Entity/TickerResponse.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Entity/CandleStickResponse.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Entity/SocketTickerResponse.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Entity/OrderBookResponse.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Entity/TransactionHistoryResponse.swift">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:Cryptocurrency/Resources"
+         name = "Resources">
+         <Group
+            location = "group:Cryptocurrency/Resources/Data"
+            name = "Data">
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Data/CryptoCurrencyDataType.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Cryptocurrency/Resources/LetterSeparator"
+            name = "LetterSeparator">
+            <FileRef
+               location = "group:Cryptocurrency/Resources/LetterSeparator/LetterSeparator.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Cryptocurrency/Resources/Module"
+            name = "Module">
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Module/BottomSheet.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Module/SegmentedCategoryView.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Module/PaddingLabel.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Module/SortButton.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Cryptocurrency/Resources/Coordinators"
+            name = "Coordinators">
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Coordinators/Coordinator.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Coordinators/AppCoordinator.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Cryptocurrency/Resources/Extensions"
+            name = "Extensions">
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Extensions/CharacterSet + Ext.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Extensions/Double + Ext.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Extensions/UISegmentedControl + Ext.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Extensions/Array + Ext.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Extensions/String + Ext.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Extensions/UIColor + Ext.swift">
+            </FileRef>
+         </Group>
+         <FileRef
+            location = "group:Cryptocurrency/Resources/AppDelegate.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Resources/SceneDelegate.swift">
+         </FileRef>
+         <FileRef
+            location = "group:Cryptocurrency/Resources/Assets.xcassets">
+         </FileRef>
+         <Group
+            location = "group:Cryptocurrency/Resources"
+            name = "LaunchScreen.storyboard">
+            <FileRef
+               location = "group:Cryptocurrency/Resources/Base.lproj/LaunchScreen.storyboard">
+            </FileRef>
+         </Group>
+         <FileRef
+            location = "group:Cryptocurrency/Resources/Info.plist">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:Cryptocurrency/TBD"
+         name = "TBD">
+         <Group
+            location = "group:Cryptocurrency/TBD/ProductService"
+            name = "ProductService">
+            <FileRef
+               location = "group:Cryptocurrency/TBD/ProductService/ProductServiceViewController.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/TBD/ProductService/ProductServiceCoordinator.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Cryptocurrency/TBD/CurrentAsset"
+            name = "CurrentAsset">
+            <FileRef
+               location = "group:Cryptocurrency/TBD/CurrentAsset/CurrentAssetViewController.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/TBD/CurrentAsset/CurrentAssetCoordinator.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Cryptocurrency/TBD/Transaction"
+            name = "Transaction">
+            <FileRef
+               location = "group:Cryptocurrency/TBD/Transaction/TransactionViewController.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/TBD/Transaction/TransactionCoordinator.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Cryptocurrency/TBD/MoreOption"
+            name = "MoreOption">
+            <FileRef
+               location = "group:Cryptocurrency/TBD/MoreOption/MoreOptionViewController.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cryptocurrency/TBD/MoreOption/MoreOptionCoordinator.swift">
+            </FileRef>
+         </Group>
+      </Group>
+   </Group>
    <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>

--- a/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailFavoriteButtonState.swift
+++ b/Cryptocurrency/Cryptocurrency/CoinDetail/CoinDetailFavoriteButtonState.swift
@@ -1,0 +1,13 @@
+//
+//  CoinDetailFavoriteButtonState.swift
+//  Cryptocurrency
+//
+//  Created by 김민성 on 2022/02/20.
+//
+
+import Foundation
+
+enum CoinDetailFavoriteButtonState: String {
+ case favorite = "star.fill"
+ case release = "star"
+}

--- a/Cryptocurrency/Cryptocurrency/Entity/CoinItemCurrency.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/CoinItemCurrency.swift
@@ -1,0 +1,13 @@
+//
+//  CoinItemCurrency.swift
+//  Cryptocurrency
+//
+//  Created by 김민성 on 2022/02/20.
+//
+
+import Foundation
+
+struct CoinItemCurrency: Codable, Hashable {
+  var orderCurrency: OrderCurrency
+  var paymentCurrency: PaymentCurrency
+}

--- a/Cryptocurrency/Cryptocurrency/Entity/Currency.swift
+++ b/Cryptocurrency/Cryptocurrency/Entity/Currency.swift
@@ -7,12 +7,21 @@
 
 import Foundation
 
-enum PaymentCurrency: String {
+enum PaymentCurrency: String, CaseIterable, Codable {
   case krw = "KRW"
   case btc = "BTC"
+
+  static func search(with name: String) -> PaymentCurrency {
+    for paymentCurrency in PaymentCurrency.allCases {
+      if paymentCurrency.rawValue == name {
+        return paymentCurrency
+      }
+    }
+    return .krw
+  }
 }
 
-enum OrderCurrency: String, CaseIterable {
+enum OrderCurrency: String, CaseIterable, Codable {
   case all = "ALL"
   case btc = "BTC"
   case eth = "ETH"

--- a/Cryptocurrency/Cryptocurrency/Exchange/Components/ExchangeSegmentedControl/ExchangeSegmentedCategoryView.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/Components/ExchangeSegmentedControl/ExchangeSegmentedCategoryView.swift
@@ -17,21 +17,31 @@ final class ExchangeSegmentedCategoryView: SegmentedCategoryView {
   enum SegmentedViewIndex: Int, CaseIterable {
     case krw = 0
     case btc = 1
+    case favorite = 2
     
-    var matchedCurrency: PaymentCurrency {
+    var matchedCurrency: PaymentCurrency? {
       switch self {
       case .krw:
         return PaymentCurrency.krw
       case .btc:
         return PaymentCurrency.btc
+      case .favorite:
+        return nil
       }
     }
     
-    static func findPaymentCurrency(with index: Int) -> PaymentCurrency {
+    static func findPaymentCurrency(with index: Int) -> PaymentCurrency? {
       guard let paymentCurrency = SegmentedViewIndex.allCases
               .filter({ $0.rawValue == index })
               .map({ $0.matchedCurrency }).first else { return .krw }
       return paymentCurrency
+    }
+
+    static func findCategory(with index: Int) -> Self {
+      guard let category = SegmentedViewIndex.allCases
+              .filter({ $0.rawValue == index })
+              .first else { return .krw }
+      return category
     }
   }
   
@@ -47,7 +57,13 @@ final class ExchangeSegmentedCategoryView: SegmentedCategoryView {
     self.segmentedControl.rx.selectedSegmentIndex
       .filter { $0 < SegmentedViewIndex.allCases.count }
       .map { SegmentedViewIndex.findPaymentCurrency(with: $0) }
+      .filter { $0 != nil } 
       .bind(to: viewModel.paymentCurrency)
+      .disposed(by: self.disposeBag)
+
+    self.segmentedControl.rx.selectedSegmentIndex
+      .map { SegmentedViewIndex.findCategory(with: $0) }
+      .bind(to: viewModel.category)
       .disposed(by: self.disposeBag)
   }
 }

--- a/Cryptocurrency/Cryptocurrency/Exchange/Components/ExchangeSegmentedControl/ExchangeSegmentedCategoryViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/Components/ExchangeSegmentedControl/ExchangeSegmentedCategoryViewModel.swift
@@ -8,11 +8,14 @@
 import Foundation
 
 import RxSwift
+import RxRelay
 
 protocol ExchangeSegmentedCategoryViewModelLogic {
-  var paymentCurrency: BehaviorSubject<PaymentCurrency> { get }
+  var paymentCurrency: BehaviorSubject<PaymentCurrency?> { get }
+  var category: BehaviorRelay<ExchangeSegmentedCategoryView.SegmentedViewIndex> { get }
 }
 
 final class ExchangeSegmentedCategoryViewModel: ExchangeSegmentedCategoryViewModelLogic {
-  let paymentCurrency = BehaviorSubject<PaymentCurrency>(value: .krw)
+  let paymentCurrency = BehaviorSubject<PaymentCurrency?>(value: .krw)
+  let category = BehaviorRelay<ExchangeSegmentedCategoryView.SegmentedViewIndex>(value: .krw)
 }

--- a/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridView.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridView.swift
@@ -38,4 +38,24 @@ class FavoriteGridView: UICollectionView {
     self.register(FavoriteGridViewCell.self, forCellWithReuseIdentifier: "FavoriteGridViewCell")
 
   }
+
+  func bind(viewModel: FavoriteGridViewModel) {
+    viewModel.cellData
+      .drive(self.rx.items) { collectionView, row, data in
+        let index = IndexPath(row: row, section: 0)
+        print(data)
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "FavoriteGridViewCell", for: index) as? FavoriteGridViewCell else { return FavoriteGridViewCell() }
+        cell.setData(with: data)
+
+        return cell
+      }.disposed(by: self.disposeBag)
+
+    self.rx.modelSelected(FavoriteGridViewCellData.self)
+      .map {
+        (orderCurrency: OrderCurrency.search(with: $0.ticker),
+         paymentCurrency: PaymentCurrency.search(with: $0.paymentCurrency))
+      }
+      .bind(to: viewModel.selectedCellData)
+      .disposed(by: self.disposeBag)
+  }
 }

--- a/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridView.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridView.swift
@@ -1,0 +1,41 @@
+//
+//  FavoriteGridView.swift
+//  Cryptocurrency
+//
+//  Created by 김민성 on 2022/02/17.
+//
+
+import RxCocoa
+import RxSwift
+
+class FavoriteGridView: UICollectionView {
+
+  // MARK: Properties
+
+  private let disposeBag = DisposeBag()
+
+  // MARK: Initializers
+
+  init() {
+    let customFlowLayout = UICollectionViewFlowLayout()
+    customFlowLayout.scrollDirection = .vertical
+    let size = (UIScreen.main.bounds.size.width - CGFloat(80)) / CGFloat(2)
+    customFlowLayout.itemSize = CGSize(width: size, height: size)
+    customFlowLayout.minimumLineSpacing = 25
+
+    super.init(frame: .zero, collectionViewLayout: customFlowLayout)
+
+    attribute()
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func attribute() {
+    self.backgroundColor = .white
+    self.contentInset = UIEdgeInsets(top: 10, left: 25, bottom: 10, right: 25)
+    self.register(FavoriteGridViewCell.self, forCellWithReuseIdentifier: "FavoriteGridViewCell")
+
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridViewCell.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridViewCell.swift
@@ -1,0 +1,81 @@
+//
+//  FavoriteGirdViewCell.swift
+//  Cryptocurrency
+//
+//  Created by 김민성 on 2022/02/17.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class FavoriteGridViewCell: UICollectionViewCell {
+
+  // MARK: Properties
+
+  private let containerView = UIView()
+  private let coinTitleLabel  = UILabel()
+  private let tickerLabel = UILabel()
+  private let titleStackView = UIStackView()
+  private let favoriteImageView = UIImageView()
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    self.attribute()
+    self.layout()
+  }
+
+  private func attribute() {
+    self.do {
+      $0.layer.borderWidth = 2
+      $0.layer.borderColor = UIColor.signature.cgColor
+      $0.layer.cornerRadius = 12
+    }
+
+    self.favoriteImageView.do {
+      $0.image = UIImage(systemName: "star.fill")
+      $0.tintColor = .signature
+    }
+
+    self.coinTitleLabel.do {
+      $0.font = .systemFont(ofSize: 20)
+      $0.numberOfLines = 2
+      $0.lineBreakMode = .byCharWrapping
+    }
+
+    self.tickerLabel.do {
+      $0.font = .systemFont(ofSize: 10)
+      $0.textColor = .darkGray
+    }
+
+    self.titleStackView.do {
+      $0.axis = .vertical
+      $0.alignment = .center
+      $0.spacing = 10
+    }
+  }
+
+  private func layout() {
+    [self.favoriteImageView ,self.titleStackView].forEach {
+      self.contentView.addSubview($0)
+    }
+
+    [self.coinTitleLabel, self.tickerLabel].forEach {
+      self.titleStackView.addArrangedSubview($0)
+    }
+
+    self.favoriteImageView.snp.makeConstraints {
+      $0.top.leading.equalToSuperview().inset(10)
+    }
+
+    self.titleStackView.snp.makeConstraints {
+      $0.center.equalTo(self.contentView)
+    }
+  }
+
+  func setData(with data: FavoriteGridViewCellData) {
+    self.coinTitleLabel.text = data.coinName
+    self.tickerLabel.text = data.ticker + "/" + data.paymentCurrency
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridViewCellData.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridViewCellData.swift
@@ -1,0 +1,14 @@
+//
+//  FavoriteGridViewCellData.swift
+//  Cryptocurrency
+//
+//  Created by 김민성 on 2022/02/16.
+//
+
+import Foundation
+
+struct FavoriteGridViewCellData {
+  let coinName: String
+  let ticker: String
+  let paymentCurrency: String
+}

--- a/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/Components/FavoriteGridView/FavoriteGridViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  FavoriteGridViewModel.swift
+//  Cryptocurrency
+//
+//  Created by 김민성 on 2022/02/17.
+//
+
+import RxCocoa
+import RxSwift
+
+protocol FavoriteGridViewModelLogic {
+  var cellData: Driver<[FavoriteGridViewCellData]> { get }
+  var favoriteGridCellData: PublishSubject<[FavoriteGridViewCellData]> { get }
+  var selectedCellData: PublishSubject<(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency)> { get }
+}
+
+final class FavoriteGridViewModel: FavoriteGridViewModelLogic {
+
+  // MARK: Properties
+
+  var cellData: Driver<[FavoriteGridViewCellData]>
+  let favoriteGridCellData = PublishSubject<[FavoriteGridViewCellData]>()
+  let selectedCellData = PublishSubject<(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency)>()
+
+  // MARK: Initializers
+
+  init() {
+    self.cellData = self.favoriteGridCellData
+      .asDriver(onErrorJustReturn: [])
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/Exchange/ExchangeUseCase.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/ExchangeUseCase.swift
@@ -11,6 +11,7 @@ protocol ExchangeUseCaseLogic {
   func fetchTicker(orderCurrency: OrderCurrency, paymentCurrency: PaymentCurrency) -> Single<Result<AllTickerResponse, APINetworkError>>
   func tickerResponse(result: Result<AllTickerResponse, APINetworkError>) -> AllTickerResponse?
   func coinListCellData(response: AllTickerResponse?) -> [CoinListViewCellData]
+  func favoriteGridCellData(currencies: [CoinItemCurrency]) -> [FavoriteGridViewCellData]
   func sortByCoinName(coinListCellData: [CoinListViewCellData], isDescending: Bool) -> [CoinListViewCellData]
   func sortByCurrentPrice(coinListCellData: [CoinListViewCellData], isDescending: Bool) -> [CoinListViewCellData]
   func sortByPriceChangedRatio(coinListCellData: [CoinListViewCellData], isDescending: Bool) -> [CoinListViewCellData]
@@ -58,6 +59,16 @@ struct ExchangeUseCase: ExchangeUseCaseLogic {
           priceDifference: $0.value.fluctate24H,
           transactionAmount: $0.value.accTradeValue24H
         )
+      }
+  }
+
+  func favoriteGridCellData(currencies: [CoinItemCurrency]) -> [FavoriteGridViewCellData] {
+    return currencies
+      .map {
+        return FavoriteGridViewCellData(
+          coinName: $0.orderCurrency.koreanName,
+          ticker: $0.orderCurrency.rawValue,
+          paymentCurrency: $0.paymentCurrency.rawValue)
       }
   }
 

--- a/Cryptocurrency/Cryptocurrency/Exchange/ExchangeViewController.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/ExchangeViewController.swift
@@ -7,17 +7,21 @@
 
 import UIKit
 
+import RxSwift
+
 final class ExchangeViewController: UIViewController {
   
   // MARK: Properties
   
   let coinListView: CoinListView
+  let favoriteGridView: FavoriteGridView
   let exchangeSegmentedCategoryView: ExchangeSegmentedCategoryView
   let exchangeSearchBar: ExchangeSearchBar
   var exchangeViewModel: ExchangeViewModelLogic
   let exchangeUseCase: ExchangeUseCaseLogic
   let networkManager: NetworkManagerLogic
 
+  private let disposeBag = DisposeBag()
 
   // MARK: Initializers
   
@@ -29,6 +33,7 @@ final class ExchangeViewController: UIViewController {
     self.exchangeViewModel = ExchangeViewModel(useCase: self.exchangeUseCase)
     self.exchangeSearchBar = ExchangeSearchBar()
     self.coinListView = CoinListView()
+    self.favoriteGridView = FavoriteGridView()
     
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
   }
@@ -43,6 +48,13 @@ final class ExchangeViewController: UIViewController {
     self.configure()
     self.layout()
   }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    BehaviorSubject<Void>(value: ())
+      .bind(to: self.exchangeViewModel.viewWillAppear)
+      .disposed(by: self.disposeBag)
+  }
   
   private func configure() {
     self.bind()
@@ -51,20 +63,51 @@ final class ExchangeViewController: UIViewController {
   private func bind() {
     self.exchangeSearchBar.bind(viewModel: self.exchangeViewModel.exchangeSearchBarViewModel)
     self.coinListView.bind(viewModel: self.exchangeViewModel.coinListViewModel)
+    self.favoriteGridView.bind(viewModel: self.exchangeViewModel.favoriteGridViewModel)
     self.coinListView.coinListSortView.bind(coinListSortViewModel: self.exchangeViewModel.coinListSortViewModel)
     self.exchangeSegmentedCategoryView.bind(viewModel: self.exchangeViewModel.exchangeSegmentedCategoryViewModel)
+
+    self.exchangeViewModel.exchangeSegmentedCategoryViewModel.category
+      .bind(onNext: self.changeContentView)
+      .disposed(by: self.disposeBag)
+  }
+
+  private func changeContentView(by category: ExchangeSegmentedCategoryView.SegmentedViewIndex) {
+    switch category {
+    case .krw:
+      self.exchangeSearchBar.isHidden = false
+      self.exchangeSegmentedCategoryView.isHidden = false
+      self.coinListView.isHidden = false
+      self.favoriteGridView.isHidden = true
+    case .btc:
+      self.exchangeSearchBar.isHidden = false
+      self.exchangeSegmentedCategoryView.isHidden = false
+      self.coinListView.isHidden = false
+      self.favoriteGridView.isHidden = true
+    case .favorite:
+      self.exchangeSearchBar.isHidden = false
+      self.exchangeSegmentedCategoryView.isHidden = false
+      self.coinListView.isHidden = true
+      self.favoriteGridView.isHidden = false
+    }
   }
   
   private func layout() {
     self.setUpNavigationBar()
     
-    [self.exchangeSegmentedCategoryView, self.coinListView].forEach { self.view.addSubview($0) }
+    [self.exchangeSegmentedCategoryView, self.coinListView, self.favoriteGridView].forEach { self.view.addSubview($0) }
     
     self.exchangeSegmentedCategoryView.snp.makeConstraints {
       $0.leading.top.equalTo(self.view.safeAreaLayoutGuide).inset(10)
     }
     
     self.coinListView.snp.makeConstraints {
+      $0.top.equalTo(self.exchangeSegmentedCategoryView.snp.bottom).offset(10)
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+    }
+
+    self.favoriteGridView.snp.makeConstraints {
       $0.top.equalTo(self.exchangeSegmentedCategoryView.snp.bottom).offset(10)
       $0.leading.trailing.equalToSuperview()
       $0.bottom.equalTo(self.view.safeAreaLayoutGuide)

--- a/Cryptocurrency/Cryptocurrency/Exchange/ExchangeViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/ExchangeViewModel.swift
@@ -42,7 +42,7 @@ final class ExchangeViewModel: ExchangeViewModelLogic {
       self.exchangeSegmentedCategoryViewModel.paymentCurrency,
       self.coinListSortViewModel.coinListSortCriteria
     ) { orderCurrency, paymentCurrency, _ in
-      useCase.fetchTicker(orderCurrency: orderCurrency, paymentCurrency: paymentCurrency) }
+      useCase.fetchTicker(orderCurrency: orderCurrency, paymentCurrency: paymentCurrency!) }
       .flatMap { $0 }
 
     let cellData = result

--- a/Cryptocurrency/Cryptocurrency/Exchange/ExchangeViewModel.swift
+++ b/Cryptocurrency/Cryptocurrency/Exchange/ExchangeViewModel.swift
@@ -100,7 +100,16 @@ final class ExchangeViewModel: ExchangeViewModelLogic {
     let favoriteCellData = userDefaultsData
       .map (useCase.favoriteGridCellData)
 
-    favoriteCellData
+    let filteredFavoriteCellData = Observable.combineLatest(
+      favoriteCellData,
+      self.exchangeSearchBarViewModel.orderCurrenciesToSearch
+    ) { favoriteCellData, filteredOrderCurrencies in
+      return favoriteCellData.filter { cellDatum in
+        filteredOrderCurrencies.values.contains(cellDatum.ticker)
+      }
+    }
+
+    filteredFavoriteCellData
       .bind(to: self.favoriteGridViewModel.favoriteGridCellData)
       .disposed(by: self.disposeBag)
 

--- a/Cryptocurrency/Cryptocurrency/UserDefaults/PersistenceManager.swift
+++ b/Cryptocurrency/Cryptocurrency/UserDefaults/PersistenceManager.swift
@@ -1,0 +1,88 @@
+//
+//  PersistenceManager.swift
+//  Cryptocurrency
+//
+//  Created by 김민성 on 2022/02/18.
+//
+
+import Foundation
+
+enum PersistenceActionType {
+ case add, remove
+}
+
+enum PersistenceManager {
+  static private let defaults = UserDefaults.standard
+
+  enum Keys {
+    static let favorites = "favorites"
+  }
+
+  static func updateWith(item: CoinItemCurrency, actionType: PersistenceActionType, completed: @escaping (UserDefaultsError?) -> Void) {
+    retrieveFavorites {
+      switch $0 {
+      case .success(let favorites):
+        var retrievedFavorite = favorites
+
+        switch actionType {
+        case .add:
+          guard !retrievedFavorite.contains(item) else {
+            completed(UserDefaultsError.unvalidItemError)
+            return
+          }
+          retrievedFavorite.append(item)
+        case .remove:
+          retrievedFavorite.removeAll {
+            $0.orderCurrency == item.orderCurrency && $0.paymentCurrency == item.paymentCurrency
+          }
+        }
+        completed(save(favorites: retrievedFavorite))
+      case .failure(let error):
+        completed(error)
+      }
+    }
+  }
+
+  static func retrieveFavorites(completed: @escaping (Result<[CoinItemCurrency], UserDefaultsError>) -> Void) {
+    guard let favoritesData = defaults.object(forKey: Keys.favorites) as? Data else {
+      completed(.success([]))
+      return
+    }
+
+    do {
+      let decoder = JSONDecoder()
+      let favorites = try decoder.decode([CoinItemCurrency].self, from: favoritesData)
+      completed(.success(favorites))
+    } catch {
+      completed(.failure(.decodingError))
+    }
+  }
+
+  static func save(favorites: [CoinItemCurrency]) -> UserDefaultsError? {
+    do {
+      let encoder = JSONEncoder()
+      let encodedFavorites = try encoder.encode(favorites)
+      defaults.set(encodedFavorites, forKey: Keys.favorites)
+      return nil
+    } catch {
+      return .encodingError
+    }
+  }
+
+  static func isContained(with item: CoinItemCurrency) -> Bool {
+    var result = false
+    retrieveFavorites {
+      switch $0 {
+      case .success(let favorite):
+        if favorite.contains(item) {
+          result = true
+        } else {
+          result = false
+        }
+      case .failure(let error):
+        print(error)
+      }
+    }
+    return result
+  }
+}

--- a/Cryptocurrency/Cryptocurrency/UserDefaults/UserDefaultsError.swift
+++ b/Cryptocurrency/Cryptocurrency/UserDefaults/UserDefaultsError.swift
@@ -1,0 +1,14 @@
+//
+//  UserDefaultsError.swift
+//  Cryptocurrency
+//
+//  Created by 김민성 on 2022/02/20.
+//
+
+import Foundation
+
+enum UserDefaultsError: Error {
+  case decodingError
+  case encodingError
+  case unvalidItemError
+}

--- a/Cryptocurrency/CryptocurrencyTests/Exchange/Spy/ExchangeUseCaseSpy.swift
+++ b/Cryptocurrency/CryptocurrencyTests/Exchange/Spy/ExchangeUseCaseSpy.swift
@@ -32,6 +32,12 @@ final class ExchangeUseCaseSpy: ExchangeUseCaseLogic {
     return self.coinListCellDataStub
   }
 
+  var favoriteGridCellDataStub: [FavoriteGridViewCellData] = []
+
+  func favoriteGridCellData(currencies: [CoinItemCurrency]) -> [FavoriteGridViewCellData] {
+    return self.favoriteGridCellDataStub
+  }
+
   var sortedByCoinNameStub: [CoinListViewCellData] = []
 
   func sortByCoinName(coinListCellData: [CoinListViewCellData], isDescending: Bool) -> [CoinListViewCellData] {


### PR DESCRIPTION
## 배경
- #42 
- 관심 코인 목록을 나타내기 위한 CollectionView를 구현하고 코인 상세화면에서 관심 추가 및 해제할 수 있는 기능을 구현해요
## 수정사항
- ExchangeSegmentedCategoryView에서 관심 목록이 동작하도록 구현해요
- UserDefualts를 관리하는 PersistanceManager를 구현해요
- FavoriteGirdView를 CollectionView로 구현하고 UserDefaults에 저장된 데이터를 기반으로 데이터를 보여줘요
- CoinDetailView에 Toggle 버튼을 추가하여 관심 목록에 추가 및 제거 기능을 구현해요
- SearchBar 입력 값의 결과가 관심 목록에 반영되도록 구현해요

## 테스트 방법
- 구동 테스트
![화면 기록 2022-02-21 오전 1 28 08](https://user-images.githubusercontent.com/56648865/154853197-a99064d4-9f05-47ef-b5a7-2535be393b11.gif)

## 리뷰 노트 
관심 목록에서 가상화폐 상세 화면에 들어갔다가 나왔을 경우 FavoriteGridView가 갱신되도록 하기 위해 다른 bind 동작과 다르게ExchangeViewcontroller의 viewWillAppear 메서드에서 새로운 스트림을 생성 해주었는데 이 부분에 대해서 이야기 해보면 좋을 거 같아요